### PR TITLE
Inlining style for the plus button

### DIFF
--- a/template/base_email_2015.html
+++ b/template/base_email_2015.html
@@ -184,12 +184,15 @@
           display: inherit !important;
           width: 100% !important;
         }
-        body span.bottom-link {
+        body span.bottom-link, span.inner-bottom-link {
           height: 26.5px !important;
           line-height: 26.5px !important;
           font-size: 13px !important;
           padding-left: 12px !important;
           min-width: 128px !important;
+        }
+        span.inner-bottom-link {
+          padding-left: 0 !important;
         }
         body span.bottom-link img {
           width: 15px !important;

--- a/template/macro/2015/layout.html
+++ b/template/macro/2015/layout.html
@@ -27,7 +27,7 @@
                                         </td>
                                         <td width="5" class="hide"></td>
                                         <td width="5"></td>
-                                        <td valign="middle">More {{heading_text|lower}}</td>
+                                        <td valign="middle"><span class="inner-bottom-link" style="font-family: 'DS3DisplaySans', Arial, serif; font-size: 18px; background-color: #005689; height: 38px; line-height: 38px; color: #FFFFFF;">More {{heading_text|lower}}</span></td>
                                     </tr>
                                 </table>
                             </span>


### PR DESCRIPTION
Exact Target wrappings were removing the style assigned to the text in the button.