### PR TITLE
US template tweaks

### DIFF
--- a/template/macro/2015/layout.html
+++ b/template/macro/2015/layout.html
@@ -80,7 +80,7 @@
                         <tr>
                             <td align="left" style="border-top: 1px solid #4BC6DF;">
                                 {% if show_heading_links and heading_link %}
-                                    <a class="heading-text" style="font-family: 'DE5DisplayEgyptianSemiBold', Georgia, serif; font-weight: 600; font-size: 24px; color: #005689;" href="{{heading_link}}">{{heading_text}}</a>
+                                    <a class="heading-text" style="font-family: 'DE5DisplayEgyptianSemiBold', Georgia, serif; font-weight: 600; font-size: 24px; color: #005689; text-decoration: none;" href="{{heading_link}}">{{heading_text}}</a>
                                 {% else %}
                                     <span class="heading-text" style="font-family: 'DE5DisplayEgyptianSemiBold', Georgia, serif; font-weight: 600; font-size: 24px; color: #005689;">{{heading_text}}</span>
                                 {% endif %}

--- a/template/us/daily/v2015_v3.html
+++ b/template/us/daily/v2015_v3.html
@@ -88,7 +88,7 @@
         show_kicker=False,
         show_heading_links=True) }}
 
-    {{ layout.story_trail(heading_text='Most shared in the last 24 hours',
+    {{ layout.story_trail(heading_text='Most shared',
         image='more-popular.jpg',
         stories=most_shared_us,
         heading_link='http://www.theguardian.com/us#most-popular',


### PR DESCRIPTION
Two tweaks to the US template: 
* Shorten "most shared" button text
* Ensure the header title links aren't underlined (which was happening in gmail)