### PR TITLE
Add jinja2 HTML minifier

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -21,6 +21,7 @@ else:
 
 jinja_environment = jinja2.Environment(
     loader=jinja2.FileSystemLoader(os.path.join(os.path.dirname(__file__), "template")),
+    extensions=['jinja2htmlcompress.HTMLCompress']
 )
 
 jinja_environment.globals.update({

--- a/jinja2htmlcompress/__init__.py
+++ b/jinja2htmlcompress/__init__.py
@@ -1,0 +1,1 @@
+from jinja2htmlcompress import HTMLCompress

--- a/jinja2htmlcompress/jinja2htmlcompress.py
+++ b/jinja2htmlcompress/jinja2htmlcompress.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+"""
+    jinja2htmlcompress
+    ~~~~~~~~~~~~~~~~~~
+
+    A Jinja2 extension that eliminates useless whitespace at template
+    compilation time without extra overhead.
+
+    :copyright: (c) 2011 by Armin Ronacher.
+    :license: BSD, see LICENSE for more details.
+"""
+import re
+from jinja2.ext import Extension
+from jinja2.lexer import Token, describe_token
+from jinja2 import TemplateSyntaxError
+
+
+_tag_re = re.compile(r'(?:<(/?)([a-zA-Z0-9_-]+)\s*|(>\s*))(?s)')
+_ws_normalize_re = re.compile(r'[ \t\r\n]+')
+
+
+class StreamProcessContext(object):
+
+    def __init__(self, stream):
+        self.stream = stream
+        self.token = None
+        self.stack = []
+
+    def fail(self, message):
+        raise TemplateSyntaxError(message, self.token.lineno,
+                                  self.stream.name, self.stream.filename)
+
+
+def _make_dict_from_listing(listing):
+    rv = {}
+    for keys, value in listing:
+        for key in keys:
+            rv[key] = value
+    return rv
+
+
+class HTMLCompress(Extension):
+    isolated_elements = set(['script', 'style', 'noscript', 'textarea'])
+    void_elements = set(['br', 'img', 'area', 'hr', 'param', 'input',
+                         'embed', 'col'])
+    block_elements = set(['div', 'p', 'form', 'ul', 'ol', 'li', 'table', 'tr',
+                          'tbody', 'thead', 'tfoot', 'tr', 'td', 'th', 'dl',
+                          'dt', 'dd', 'blockquote', 'h1', 'h2', 'h3', 'h4',
+                          'h5', 'h6', 'pre'])
+    breaking_rules = _make_dict_from_listing([
+        (['p'], set(['#block'])),
+        (['li'], set(['li'])),
+        (['td', 'th'], set(['td', 'th', 'tr', 'tbody', 'thead', 'tfoot'])),
+        (['tr'], set(['tr', 'tbody', 'thead', 'tfoot'])),
+        (['thead', 'tbody', 'tfoot'], set(['thead', 'tbody', 'tfoot'])),
+        (['dd', 'dt'], set(['dl', 'dt', 'dd']))
+    ])
+
+    def is_isolated(self, stack):
+        for tag in reversed(stack):
+            if tag in self.isolated_elements:
+                return True
+        return False
+
+    def is_breaking(self, tag, other_tag):
+        breaking = self.breaking_rules.get(other_tag)
+        return breaking and (tag in breaking or
+            ('#block' in breaking and tag in self.block_elements))
+
+    def enter_tag(self, tag, ctx):
+        while ctx.stack and self.is_breaking(tag, ctx.stack[-1]):
+            self.leave_tag(ctx.stack[-1], ctx)
+        if tag not in self.void_elements:
+            ctx.stack.append(tag)
+
+    def leave_tag(self, tag, ctx):
+        if not ctx.stack:
+            ctx.fail('Tried to leave "%s" but something closed '
+                     'it already' % tag)
+        if tag == ctx.stack[-1]:
+            ctx.stack.pop()
+            return
+        for idx, other_tag in enumerate(reversed(ctx.stack)):
+            if other_tag == tag:
+                for num in xrange(idx + 1):
+                    ctx.stack.pop()
+            elif not self.breaking_rules.get(other_tag):
+                break
+
+    def normalize(self, ctx):
+        pos = 0
+        buffer = []
+        def write_data(value):
+            if not self.is_isolated(ctx.stack):
+                value = _ws_normalize_re.sub(' ', value.strip())
+            buffer.append(value)
+
+        for match in _tag_re.finditer(ctx.token.value):
+            closes, tag, sole = match.groups()
+            preamble = ctx.token.value[pos:match.start()]
+            write_data(preamble)
+            if sole:
+                write_data(sole)
+            else:
+                buffer.append(match.group())
+                (closes and self.leave_tag or self.enter_tag)(tag, ctx)
+            pos = match.end()
+
+        write_data(ctx.token.value[pos:])
+        return u''.join(buffer)
+
+    def filter_stream(self, stream):
+        ctx = StreamProcessContext(stream)
+        for token in stream:
+            if token.type != 'data':
+                yield token
+                continue
+            ctx.token = token
+            value = self.normalize(ctx)
+            yield Token(token.lineno, 'data', value)
+
+
+class SelectiveHTMLCompress(HTMLCompress):
+
+    def filter_stream(self, stream):
+        ctx = StreamProcessContext(stream)
+        strip_depth = 0
+        while 1:
+            if stream.current.type == 'block_begin':
+                if stream.look().test('name:strip') or \
+                   stream.look().test('name:endstrip'):
+                    stream.skip()
+                    if stream.current.value == 'strip':
+                        strip_depth += 1
+                    else:
+                        strip_depth -= 1
+                        if strip_depth < 0:
+                            ctx.fail('Unexpected tag endstrip')
+                    stream.skip()
+                    if stream.current.type != 'block_end':
+                        ctx.fail('expected end of block, got %s' %
+                                 describe_token(stream.current))
+                    stream.skip()
+            if strip_depth > 0 and stream.current.type == 'data':
+                ctx.token = stream.current
+                value = self.normalize(ctx)
+                yield Token(stream.current.lineno, 'data', value)
+            else:
+                yield stream.current
+            stream.next()
+
+
+def test():
+    from jinja2 import Environment
+    env = Environment(extensions=[HTMLCompress])
+    tmpl = env.from_string('''
+        <html>
+          <head>
+            <title>{{ title }}</title>
+          </head>
+          <script type=text/javascript>
+            if (foo < 42) {
+              document.write('Foo < Bar');
+            }
+          </script>
+          <body>
+            <li><a href="{{ href }}">{{ title }}</a><br>Test   Foo
+            <li><a href="{{ href }}">{{ title }}</a><img src=test.png>
+          </body>
+        </html>
+    ''')
+    print tmpl.render(title=42, href='index.html')
+
+    env = Environment(extensions=[SelectiveHTMLCompress])
+    tmpl = env.from_string('''
+        Normal   <span>  unchanged </span> stuff
+        {% strip %}Stripped <span class=foo  >   test   </span>
+        <a href="foo">  test </a> {{ foo }}
+        Normal <stuff>   again {{ foo }}  </stuff>
+        <p>
+          Foo<br>Bar
+          Baz
+        <p>
+          Moep    <span>Test</span>    Moep
+        </p>
+        {% endstrip %}
+    ''')
+    print tmpl.render(foo=42)
+
+
+if __name__ == '__main__':
+    test()

--- a/template/index.html
+++ b/template/index.html
@@ -22,33 +22,33 @@
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tbody><tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        UK Daily Email, <a class="story-title" href="/daily-email/v1" > v1</a> | <a class="story-title" href="/daily-email/v2015" > v2015</a> |
-                         <a class="story-title" href="/headline" >headline</a> |
+                        UK Daily Email, <a class="story-title" href="/daily-email/v1" > v1</a>{{ " " }}|{{ " " }}<a class="story-title" href="/daily-email/v2015" > v2015</a>{{ " " }}|{{ " " }}
+                         <a class="story-title" href="/headline" >headline</a>{{ " " }}|{{ " " }}
                         <a class="story-title" href="/daily-email/india" >India</a>
                     </td>
                 </tr><tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        Daily Email - US edition: <a class="story-title" href="/daily-email-us/v1" >v1</a> |
-                        <a class="story-title" href="/daily-email-us/v3" >v3</a> |
-                        <a class="story-title" href="/daily-email-us/v6" >v6</a> |
-                        <a class="story-title" href="/daily-email-us/v7" >v7</a> |
-                        <a class="story-title" href="/daily-email-us/v2015" >v2015</a> |
-                        <a class="story-title" href="/daily-email-us/v2015_v2" >v2015_v2</a> |
-                        <a class="story-title" href="/daily-email-us/v2015_v3" >v2015_v3</a> |
+                        Daily Email - US edition: <a class="story-title" href="/daily-email-us/v1" >v1</a>{{ " " }}|{{ " " }}
+                        <a class="story-title" href="/daily-email-us/v3" >v3</a>{{ " " }}|{{ " " }}
+                        <a class="story-title" href="/daily-email-us/v6" >v6</a>{{ " " }}|{{ " " }}
+                        <a class="story-title" href="/daily-email-us/v7" >v7</a>{{ " " }}|{{ " " }}
+                        <a class="story-title" href="/daily-email-us/v2015" >v2015</a>{{ " " }}|{{ " " }}
+                        <a class="story-title" href="/daily-email-us/v2015_v2" >v2015_v2</a>{{ " " }}|{{ " " }}
+                        <a class="story-title" href="/daily-email-us/v2015_v3" >v2015_v3</a>{{ " " }}|{{ " " }}
                         <a class="story-title" href="/headline/us">headline</a>
                     </td>
                 </tr>
 
                 <tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        Best of US Opinion <a class="story-title" href="/us-opinion/v1" >v1</a> | <a class="story-title" href="/us-opinion/v2" >v2</a> | <a class="story-title" href="/us-opinion/v3" >v3</a>
+                        Best of US Opinion <a class="story-title" href="/us-opinion/v1" >v1</a>{{ " " }}|{{ " " }}<a class="story-title" href="/us-opinion/v2" >v2</a>{{ " " }}|{{ " " }}<a class="story-title" href="/us-opinion/v3" >v3</a>
                     </td>
                 </tr>
 
                 <tr>
                     <td style="padding: 10px 20px 20px 20px;">
                     Daily Email - Australia edition
-                        <a class="story-title" href="/daily-email-aus/v1" >v1</a> | <a class="story-title" href="/daily-email-aus/v2" >v2 - with Eyewitness</a> | <a class="story-title" href="/daily-email-aus/v3" >v3 - with MostShared</a> | <a class="story-title" href="/daily-email-aus/v2015" >v2015</a> | <a class="story-title" href="/headline/au">headline</a>
+                        <a class="story-title" href="/daily-email-aus/v1" >v1</a>{{ " " }}|{{ " " }}<a class="story-title" href="/daily-email-aus/v2" >v2 - with Eyewitness</a>{{ " " }}|{{ " " }}<a class="story-title" href="/daily-email-aus/v3" >v3 - with MostShared</a>{{ " " }}|{{ " " }}<a class="story-title" href="/daily-email-aus/v2015" >v2015</a>{{ " " }}|{{ " " }}<a class="story-title" href="/headline/au">headline</a>
                     </td>
                 </tr>
                 <tr>
@@ -82,15 +82,15 @@
 
                 <tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/comment-is-free/v1" >Comment is free, v1</a> |
-                        <a class="story-title" href="/comment-is-free/v2" >v2</a> | <a class="story-title" href="/comment-is-free/v3">v3</a> | <a class="story-title" href="/headline/uk/opinion/v1">v1 headline</a>
+                        <a class="story-title" href="/comment-is-free/v1" >Comment is free, v1</a>{{ " " }}|{{ " " }}
+                        <a class="story-title" href="/comment-is-free/v2" >v2</a>{{ " " }}|{{ " " }}<a class="story-title" href="/comment-is-free/v3">v3</a>{{ " " }}|{{ " " }}<a class="story-title" href="/headline/uk/opinion/v1">v1 headline</a>
                     </td>
                 </tr>
 
                 <tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/fashion-statement/v1" >Fashion statement, v1</a> | <a class="story-title" href="/fashion-statement/v2" >v2</a>
- | <a class="story-title" href="/fashion-statement/v3" >v3</a>
+                        <a class="story-title" href="/fashion-statement/v1" >Fashion statement, v1</a>{{ " " }}|{{ " " }}<a class="story-title" href="/fashion-statement/v2" >v2</a>
+{{ " " }}|{{ " " }}<a class="story-title" href="/fashion-statement/v3" >v3</a>
                     </td>
                 </tr><tr>
                     <td style="padding: 10px 20px 20px 20px;">
@@ -106,22 +106,22 @@
 
                 <tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/close-up/v1" >Close up, v1</a> |
-                        <a class="story-title" href="/close-up/v2" >v2</a> |
+                        <a class="story-title" href="/close-up/v1" >Close up, v1</a>{{ " " }}|{{ " " }}
+                        <a class="story-title" href="/close-up/v2" >v2</a>{{ " " }}|{{ " " }}
                         <a class="story-title" href="/close-up/v3" >v3</a>
                     </td>
                 </tr>
 
                 <tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        Film today email <a class="story-title" href="/film-today/v1" >v1</a> | <a class="story-title" href="/film-today/v2" >v2</a> | <a href="/headline/film/v1" class="story-title">Headline v1</a> | <a href="/headline/film" class="story-title">Headline v2</a>
+                        Film today email <a class="story-title" href="/film-today/v1" >v1</a>{{ " " }}|{{ " " }}<a class="story-title" href="/film-today/v2" >v2</a>{{ " " }}|{{ " " }}<a href="/headline/film/v1" class="story-title">Headline v1</a>{{ " " }}|{{ " " }}<a href="/headline/film" class="story-title">Headline v2</a>
                     </td>
                 </tr>
 
                 <tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/sleeve-notes/v1" >Sleeve notes, v1</a> |
-                        <a class="story-title" href="/sleeve-notes/v2" >v2</a> |
+                        <a class="story-title" href="/sleeve-notes/v1" >Sleeve notes, v1</a>{{ " " }}|{{ " " }}
+                        <a class="story-title" href="/sleeve-notes/v2" >v2</a>{{ " " }}|{{ " " }}
                         <a class="story-title" href="/sleeve-notes/v3" >v3</a>
                     </td>
                 </tr>
@@ -141,7 +141,7 @@
                     </td>
                 </tr><tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/most-shared/v1" >Most shared (Global)</a> | <a class="story-title" href="/most-shared/uk/v1" >Most shared (UK)</a> | <a class="story-title" href="/most-shared/au/v1" >Most shared (AU)</a> | <a class="story-title" href="/most-shared/us/v1" >Most shared (US)</a>
+                        <a class="story-title" href="/most-shared/v1" >Most shared (Global)</a>{{ " " }}|{{ " " }}<a class="story-title" href="/most-shared/uk/v1" >Most shared (UK)</a>{{ " " }}|{{ " " }}<a class="story-title" href="/most-shared/au/v1" >Most shared (AU)</a>{{ " " }}|{{ " " }}<a class="story-title" href="/most-shared/us/v1" >Most shared (US)</a>
                     </td>
                 </tr><tr>
                     <td style="padding: 10px 20px 20px 20px;">

--- a/template/macro/2015/layout.html
+++ b/template/macro/2015/layout.html
@@ -27,7 +27,7 @@
                                         </td>
                                         <td width="5" class="hide"></td>
                                         <td width="5"></td>
-                                        <td valign="middle"><span class="inner-bottom-link" style="font-family: 'DS3DisplaySans', Arial, serif; font-size: 18px; background-color: #005689; height: 38px; line-height: 38px; color: #FFFFFF;">More {{heading_text|lower}}</span></td>
+                                        <td valign="middle"><span class="inner-bottom-link" style="font-family: 'DS3DisplaySans', Arial, serif; font-size: 18px; background-color: #005689; height: 38px; line-height: 38px; color: #FFFFFF;">More{{ " " }}{{heading_text|lower}}</span></td>
                                     </tr>
                                 </table>
                             </span>


### PR DESCRIPTION
This adds an [HTML minifer](https://github.com/mitsuhiko/jinja2-htmlcompress) to the templates, and some changes to the US template so that certain whitespace doesn't get squashed.

It currently compresses everything but it might be better to use `SelectiveHTMLCompress` and set up a new test template for minifying - I'll have a look at that next. 