### PR TITLE
Add image width capping

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -30,7 +30,7 @@ jinja_environment.globals.update({
 jinja_environment.filters.update({
         'first_paragraph': template_filters.first_paragraph,
         'urlencode': template_filters.urlencode,
-        'largest_image': template_filters.largest_image,
+        'get_image': template_filters.get_image,
         'get_tone': template_filters.get_tone,
         'get_keyword': template_filters.get_keyword,
         'image_of_width': template_filters.image_of_width,

--- a/template/au/morning/v1.html
+++ b/template/au/morning/v1.html
@@ -81,7 +81,7 @@
 													{% if loop.first %}
 
 													<p style="text-align: center;">
-													<a href="{{story.webUrl}}" title=""><img width="270px" border="0"style="border-color: #000000; margin: 0px;" alt="" src="{{story|largest_image|asset_url}}" /></a></p>
+													<a href="{{story.webUrl}}" title=""><img width="270px" border="0"style="border-color: #000000; margin: 0px;" alt="" src="{{story|get_image|asset_url}}" /></a></p>
 													{% endif %}
 
 													<p><a href="{{story.webUrl}}" class="story-title">{{story.fields.headline}}</a><br />{{story.fields.trailText}}</p>

--- a/template/macro/2015/layout.html
+++ b/template/macro/2015/layout.html
@@ -45,7 +45,7 @@
 
 {% macro image(image, image_heading, heading_text, heading_link, heading_colour='#424242', heading_text_colour='#ffffff', bg_colour='#424242', caption_colour='#ffffff', source_colour='#ffffff') -%}
 
-{% set picture = image[0]|largest_image(image_type='main') %}
+{% set picture = image[0]|get_image(image_type='main') %}
     <table cellspacing="0" cellpadding="0" border="0" style="margin: 0px; padding: 0px; width: 100%;">
         <tr>
             <td class="mobile" width="0"></td>

--- a/template/macro/2015/stories.html
+++ b/template/macro/2015/stories.html
@@ -1,7 +1,7 @@
 {% macro story(story, standfirst=False, more_thumbs, index, first=False, thumbnail=False, show_story_text=True, first_para=False, share_links=True, use_standfirst=False, popular=False, show_kicker=True) -%}
   {% set tone = story|get_tone() %}
   {% set keyword = story|get_keyword() %}
-  {% set picture = story|largest_image(image_type='thumbnail', hard_limit=600) %}
+  {% set picture = story|largest_image(image_type='thumbnail', max_width=600) %}
   {% if popular %}
     <table cellspacing="0" cellpadding="0" border="0" width="600">
       <tr>

--- a/template/macro/2015/stories.html
+++ b/template/macro/2015/stories.html
@@ -1,7 +1,7 @@
 {% macro story(story, standfirst=False, more_thumbs, index, first=False, thumbnail=False, show_story_text=True, first_para=False, share_links=True, use_standfirst=False, popular=False, show_kicker=True) -%}
   {% set tone = story|get_tone() %}
   {% set keyword = story|get_keyword() %}
-  {% set picture = story|largest_image(image_type='thumbnail', max_width=600) %}
+  {% set picture = story|get_image(image_type='thumbnail', max_width=600) %}
   {% if popular %}
     <table cellspacing="0" cellpadding="0" border="0" width="600">
       <tr>

--- a/template/macro/2015/stories.html
+++ b/template/macro/2015/stories.html
@@ -1,7 +1,7 @@
 {% macro story(story, standfirst=False, more_thumbs, index, first=False, thumbnail=False, show_story_text=True, first_para=False, share_links=True, use_standfirst=False, popular=False, show_kicker=True) -%}
   {% set tone = story|get_tone() %}
   {% set keyword = story|get_keyword() %}
-  {% set picture = story|largest_image(image_type='thumbnail') %}
+  {% set picture = story|largest_image(image_type='thumbnail', hard_limit=600) %}
   {% if popular %}
     <table cellspacing="0" cellpadding="0" border="0" width="600">
       <tr>

--- a/template/macro/layout.html
+++ b/template/macro/layout.html
@@ -28,7 +28,7 @@
 
 {% macro image(image, heading_text, heading_link, heading_colour='#424242', heading_text_colour='#ffffff', bg_colour='#424242', caption_colour='#ffffff', source_colour='#ffffff') -%}
 
-{% set picture = image[0]|largest_image(image_type='main') %}
+{% set picture = image[0]|get_image(image_type='main') %}
 
 <tr><td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="{{ bg_colour }}" style="padding-bottom: 20px;">
@@ -89,7 +89,7 @@
 {% macro trail_image(image, heading_text, heading_link, heading_colour='#424242', heading_text_colour='#ffffff', image_only=False) -%}
 {% set story = image[0] %}
 
-{% set picture = image[0]|largest_image %}
+{% set picture = image[0]|get_image %}
 
 {% if picture %}
 <tr><td>

--- a/template_filters.py
+++ b/template_filters.py
@@ -16,7 +16,7 @@ def first_paragraph(text):
 def urlencode(url):
     return  urllib.quote_plus(url.encode('utf8'))
 
-def largest_image(content, image_type='thumbnail', hard_limit=None):
+def largest_image(content, image_type='thumbnail', max_width=None):
 	if not 'elements' in content:
 		logging.debug(content)
 		return None
@@ -28,7 +28,7 @@ def largest_image(content, image_type='thumbnail', hard_limit=None):
 
 	def too_big(image):
 		width = int(image['typeData']['width'])
-		return hard_limit and width > hard_limit
+		return max_width and width > max_width
 
 	def widest_image(current_largest_image, image):
 		if not current_largest_image:

--- a/template_filters.py
+++ b/template_filters.py
@@ -16,7 +16,7 @@ def first_paragraph(text):
 def urlencode(url):
     return  urllib.quote_plus(url.encode('utf8'))
 
-def largest_image(content, image_type='thumbnail', max_width=None):
+def get_image(content, image_type='thumbnail', max_width=None):
 	if not 'elements' in content:
 		logging.debug(content)
 		return None
@@ -30,17 +30,17 @@ def largest_image(content, image_type='thumbnail', max_width=None):
 		width = int(image['typeData']['width'])
 		return max_width and width > max_width
 
-	def widest_image(current_largest_image, image):
-		if not current_largest_image:
+	def best_image(current_best_image, image):
+		if not current_best_image:
 			return image
 
-		if current_largest_image['typeData']['width'] > image['typeData']['width']:
-			return current_largest_image
+		if current_best_image['typeData']['width'] > image['typeData']['width']:
+			return current_best_image
 		return image
 
 	assets = [asset for asset in images[0]['assets'] if not too_big(asset)]
 
-	biggest_image = reduce(widest_image, assets)
+	biggest_image = reduce(best_image, assets)
 	return biggest_image
 
 def get_tone(content):

--- a/template_filters.py
+++ b/template_filters.py
@@ -16,14 +16,19 @@ def first_paragraph(text):
 def urlencode(url):
     return  urllib.quote_plus(url.encode('utf8'))
 
-def largest_image(content, image_type='thumbnail'):
+def largest_image(content, image_type='thumbnail', hard_limit=None):
 	if not 'elements' in content:
 		logging.debug(content)
 		return None
 
 	images = [element for element in content['elements'] if element['relation'] == image_type]
+
 	if not images:
 		return None
+
+	def too_big(image):
+		width = int(image['typeData']['width'])
+		return hard_limit and width > hard_limit
 
 	def widest_image(current_largest_image, image):
 		if not current_largest_image:
@@ -33,7 +38,9 @@ def largest_image(content, image_type='thumbnail'):
 			return current_largest_image
 		return image
 
-	biggest_image = reduce(widest_image, images[0]['assets'])
+	assets = [asset for asset in images[0]['assets'] if not too_big(asset)]
+
+	biggest_image = reduce(widest_image, assets)
 	return biggest_image
 
 def get_tone(content):


### PR DESCRIPTION
This is a slight change to the `largest_image` filter to allow a hard limit (width) to be passed in. If it's there, only images that are below that width will make it through the filter.

Should fix a bug where some very big images have been appearing in the 2015 template:
![screen shot 2015-11-12 at 15 24 24](https://cloud.githubusercontent.com/assets/1064734/11122115/85a9a924-8951-11e5-92ec-22c7d8f29c62.png)
