### PR TITLE
NHS Special: temporary UK email

### DIFF
--- a/email_definitions/uk.py
+++ b/email_definitions/uk.py
@@ -8,11 +8,13 @@ import data_sources.technology as tech_data
 import handlers
 import mail_renderer as mr
 
+from container_api import container
+
 client = mr.client
 
 
 class DailyEmail(handlers.EmailTemplate):
-	recognized_versions = ['v1', 'v1-register', 'india', 'v2015']
+	recognized_versions = ['v1', 'v1-register', 'india', 'v2015', 'nhs']
 
 	ad_tag = 'email-guardian-today'
 	ad_config = {
@@ -40,6 +42,10 @@ class DailyEmail(handlers.EmailTemplate):
 			india_recent = ds.IndiaDataSource(client),
 			),
 		'v2015': base_data_sources,
+		'nhs': base_data_sources.using(
+			nhs_special = container.for_id('346f91dc-60a5-41f1-a78e-513f6f379cec'),
+			top_stories = container.for_id('uk-alpha/news/regular-stories')
+			),
 	})
 
 	base_priorities = immutable.make_list(('top_stories', 6),
@@ -56,6 +62,7 @@ class DailyEmail(handlers.EmailTemplate):
 					('business', 2), ('technology', 2), ('travel', 2),
 					('lifeandstyle', 2), ('eye_witness', 1)],
 		'v2015': base_priorities,
+		'nhs': base_priorities.cons(('nhs_special', 1)),
 		})
 
 	template_names = immutable.make_dict({
@@ -63,6 +70,7 @@ class DailyEmail(handlers.EmailTemplate):
 		'v1-register': 'uk/daily/v1-register',
 		'india': 'uk/daily/india',
 		'v2015': 'uk/daily/v2015',
+		'nhs': 'uk/daily/nhs',
 	})
 
 	def exclude_from_deduplication(self):

--- a/email_definitions/uk.py
+++ b/email_definitions/uk.py
@@ -62,7 +62,7 @@ class DailyEmail(handlers.EmailTemplate):
 					('business', 2), ('technology', 2), ('travel', 2),
 					('lifeandstyle', 2), ('eye_witness', 1)],
 		'v2015': base_priorities,
-		'nhs': base_priorities.cons(('nhs_special', 1)),
+		'nhs': base_priorities.cons(('nhs_special', 2)),
 		})
 
 	template_names = immutable.make_dict({

--- a/template/index.html
+++ b/template/index.html
@@ -26,7 +26,8 @@
                         <a class="story-title" href="/daily-email/v1-register" > v1-register</a> |
                         <a class="story-title" href="/daily-email/v2015" > v2015</a> |
                          <a class="story-title" href="/headline" >headline</a> |
-                        <a class="story-title" href="/daily-email/india" >India</a>
+                        <a class="story-title" href="/daily-email/india" >India</a> |
+                        <a class="story-title" href="/daily-email/nhs" >NHS special</a>
                     </td>
                 </tr><tr>
                     <td style="padding: 10px 20px 20px 20px;">

--- a/template/uk/daily/nhs.html
+++ b/template/uk/daily/nhs.html
@@ -16,13 +16,6 @@
 
 {% block content %}
 
-    {{ layout.story_trail(heading_text='This is the NHS',
-        stories=nhs_special,
-        heading_link='http://www.theguardian.com/society/series/this-is-the-nhs',
-        heading_colour='#63717a',
-        top_thumb=True,
-        standfirst=False) }}
-
     {{ layout.story_trail(heading_text='Editor\'s picks',
         stories=top_stories,
         heading_link='http://www.theguardian.com',
@@ -30,6 +23,14 @@
         top_thumb=True,
         standfirst=False) }}
 
+
+    {{ layout.story_trail(heading_text='This is the NHS',
+        stories=nhs_special,
+        heading_link='http://www.theguardian.com/society/series/this-is-the-nhs',
+        heading_colour='#63717a',
+        top_thumb=True,
+        standfirst=False) }}
+        
     {{ layout.advert(ads.leaderboard_v1) }}
 
     {{ layout.story_trail(

--- a/template/uk/daily/nhs.html
+++ b/template/uk/daily/nhs.html
@@ -1,0 +1,101 @@
+{# Daily (Guardian Today) email template #}
+
+{% extends 'base_email.html' %}
+{% import 'macro/layout.html' as layout %}
+
+
+{% set title = 'the guardian today' %}
+{% set title_link = 'http://www.theguardian.com' %}
+{% set title_colour = '#333333' %}
+{% set logo_background = '#004179' %}
+{% set facebook_page = 'theguardian' %}
+{% set twitter_account = 'guardian' %}
+{% set footer_colour = 'light' %}
+
+{% block title %}Guardian Today{% endblock %}
+
+{% block content %}
+
+    {{ layout.story_trail(heading_text='This is the NHS',
+        stories=nhs_special,
+        heading_link='http://www.theguardian.com/society/series/this-is-the-nhs',
+        heading_colour='#63717a',
+        top_thumb=True,
+        standfirst=False) }}
+
+    {{ layout.story_trail(heading_text='Editor\'s picks',
+        stories=top_stories,
+        heading_link='http://www.theguardian.com',
+        heading_colour='#c22d05',
+        top_thumb=True,
+        standfirst=False) }}
+
+    {{ layout.advert(ads.leaderboard_v1) }}
+
+    {{ layout.story_trail(
+        heading_text='Most viewed in last 24 hours',
+        stories=most_viewed,
+        heading_link='http://www.theguardian.com/mostviewed',
+        heading_colour='#004179',
+        top_thumb=True,
+        standfirst=False) }}
+
+    {{ layout.story_trail(
+        heading_text='Sport',
+        stories=sport,
+        heading_link='http://www.theguardian.com/sport',
+        heading_colour='#20a111',
+        standfirst=False) }}
+
+    {{ layout.story_trail(
+        heading_text='Comment is free',
+        stories=comment,
+        heading_link='http://www.theguardian.com/commentisfree',
+        heading_colour='#0061a6',
+        standfirst=False) }}
+
+    {{ layout.story_trail(
+        heading_text='Culture',
+        stories=culture,
+        heading_link='http://www.theguardian.com/culture',
+        heading_colour='#d1008b',
+        standfirst=False) }}
+
+    {{ layout.story_trail(
+        heading_text='Business',
+        stories=business,
+        heading_link='http://www.theguardian.com/business',
+        heading_colour='#004179',
+        thumbnail=False,
+        standfirst=False) }}
+
+    {{ layout.advert(ads.leaderboard_v2) }}
+
+    {{ layout.story_trail(
+        heading_text='Technology',
+        stories=technology,
+        heading_link='http://www.theguardian.com/technology',
+        heading_colour='#d61d00',
+        standfirst=False) }}
+
+    {{ layout.story_trail(
+        heading_text='Travel',
+        stories=travel,
+        heading_link='http://www.theguardian.com/travel',
+        heading_colour='#066ec9',
+        standfirst=False) }}
+
+    {{ layout.story_trail(
+        heading_text='Life and style',
+        stories=lifeandstyle,
+        heading_link='http://www.theguardian.com/lifeandstyle',
+        heading_colour='#ea721e',
+        standfirst=False) }}
+
+    {% include 'components/eyewitness.html' %}
+
+{% endblock content %}
+
+{% set sections = (('Football', 'http://www.theguardian.com/football'),
+                   ('Comment is free', 'http://www.theguardian.com/commentisfree'),
+                   ('Environment', 'http://www.theguardian.com/environment')) %}


### PR DESCRIPTION
While the NHS campaign is running this provides a temporary email that can be used instead of the regular UK morning mail.