### PR TITLE
Bookmarks: v2: Talking Points update

### DIFF
--- a/email_definitions/culture.py
+++ b/email_definitions/culture.py
@@ -132,7 +132,7 @@ class CloseUp(handlers.EmailTemplate):
 
 class Bookmarks(handlers.EmailTemplate):
     
-    recognized_versions = immutable.make_list('v1')
+    recognized_versions = immutable.make_list('v1', 'v2')
 
     ad_tag = 'email-bookmarks'
     ad_config = immutable.make_dict({
@@ -150,7 +150,9 @@ class Bookmarks(handlers.EmailTemplate):
     })
 
     data_sources = immutable.make_dict({
-        'v1' : base_data_sources,
+        'v1': base_data_sources,
+        'v2': base_data_sources.using(
+            talking_points=container.for_id('c04946d0-6483-4b29-ad3c-37bd2e2058c8')),
     })
  
     priority_list = immutable.make_dict({
@@ -160,8 +162,16 @@ class Bookmarks(handlers.EmailTemplate):
             ('book_reviews', 3),
             ('books_blog', 3),
             ('book_podcasts', 1),
-            ('how_to_draw', 1))    
-    })
+            ('how_to_draw', 1)),   
+       'v2': immutable.make_list(
+            ('books_picks', 5),
+            ('books_most_viewed', 3),
+            ('book_reviews', 3),
+            ('talking_points', 6),
+            ('book_podcasts', 1),
+            ('how_to_draw', 1)),   
+     })
     template_names = immutable.make_dict({
         'v1': 'culture/bookmarks/v1',
+        'v2': 'culture/bookmarks/v2',
     })

--- a/template/culture/bookmarks/v2.html
+++ b/template/culture/bookmarks/v2.html
@@ -40,9 +40,9 @@
         top_thumb=True) }}
 
 {{ layout.story_trail(
-        heading_text='Books blog',
-        stories=books_blog,
-        heading_link='http://www.theguardian.com/books/booksblog',
+        heading_text='Talking Points',
+        stories=talking_points,
+        heading_link='http://www.theguardian.com/books#talking-points',
         heading_colour='#d1008b',
         top_thumb=True) }}
 

--- a/template/index.html
+++ b/template/index.html
@@ -104,7 +104,7 @@
 
                 <tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        Bookmarks: <a class="story-title" href="/bookmarks/v1" >v1</a>
+                        Bookmarks: <a class="story-title" href="/bookmarks/v1" >v1</a> | <a class="story-title" href="/bookmarks/v2" >v2</a>
                     </td>
                 </tr>
 


### PR DESCRIPTION
Talking Points is now drawn from the relevant container and more stories are drawn from it.

The old Talking Points section has now been more accurately named Book Blogs.

I've reviewed this with Sian Cain and we'll run a split test for the next email.