### PR TITLE
Comments: survive empty DAPI responses

### DIFF
--- a/data_source.py
+++ b/data_source.py
@@ -231,7 +231,8 @@ class MultiContentDataSource(ItemDataSource):
 
     def _do_call(self, **criteria):
         if not self.content_ids:
-            raise DataSourceException("content_ids must be set before calling fetch_data()")
+            logging.warning("content_ids must be set before calling fetch_data()")
+            return []
 
         result = []
         for id in self.content_ids:


### PR DESCRIPTION
DAPI might return an empty list of stories being discussed. Currently this blows up the email but this change logs the fact that the result is empty but should allow the email to still be generated.