### PR TITLE
Deduplication: strip failed reads

### DIFF
--- a/deduplication.py
+++ b/deduplication.py
@@ -20,7 +20,7 @@ def build_unique_trailblocks(data, priority_list, excluded=None):
 
         unique_subset = []
         unique_subsets[data_set_name] = unique_subset
-        source_data = data[data_set_name]
+        source_data = [item for item in data[data_set_name] if item]
         for item in source_data:
             if item['id'] not in items_seen_so_far and len(unique_subset) < size:
                 unique_subset.append(item)


### PR DESCRIPTION
Where a content item cannot be resolved it should be ignored for the purpose of deduping.

This is guard fix but it might be better to elimnate None results from the source that generates them.