### PR TITLE
CAPI: breakout mini-client

### DIFF
--- a/capi.py
+++ b/capi.py
@@ -1,0 +1,40 @@
+import json
+import urllib
+
+from google.appengine.api import urlfetch
+from google.appengine.api import memcache
+
+import pysistence as immutable
+
+import defaults
+import configuration
+
+
+default_params = immutable.make_dict({
+	'show-fields': ",".join(defaults.content_item_fields),
+	'api-key': configuration.read('CAPI_KEY')
+	})
+
+def read_item(internal_id):
+	capi_base_url = configuration.read('CAPI_BASE_URL')
+
+	item_url = "{0}/{1}?{2}".format(capi_base_url, internal_id, urllib.urlencode(default_params))
+	#logging.info(item_url)
+	
+	cached_response = memcache.get(item_url)
+
+	if cached_response:
+		return cached_response
+
+	
+	result = urlfetch.fetch(item_url, deadline=8)
+
+	if result.status_code == 200:
+		data = json.loads(result.content)
+		item_data = data.get('response', {}).get('content', {})
+
+		if len(result.content) < defaults.MAX_MEMCACHE_LENGTH:
+			memcache.set(item_url, item_data, defaults.CACHE_TIME)
+		return item_data
+
+	return None

--- a/container_api/container.py
+++ b/container_api/container.py
@@ -6,45 +6,15 @@ import traceback
 from google.appengine.api import urlfetch
 from google.appengine.api import memcache
 
-import pysistence as immutable
-
 import defaults
 import configuration
-
-default_params = immutable.make_dict({
-	'show-fields': ",".join(defaults.content_item_fields),
-	'api-key': configuration.read('CAPI_KEY')
-	})
+import capi
 
 def for_id(container_id):
 	return ContainerDataSource(container_id)
 
 def for_front(front_id, metadata=None):
 	return FrontDataSource(front_id, metadata)
-
-def read_capi_item(internal_id):
-	capi_base_url = configuration.read('CAPI_BASE_URL')
-
-	item_url = "{0}/{1}?{2}".format(capi_base_url, internal_id, urllib.urlencode(default_params))
-	#logging.info(item_url)
-	
-	cached_response = memcache.get(item_url)
-
-	if cached_response:
-		return cached_response
-
-	
-	result = urlfetch.fetch(item_url, deadline=8)
-
-	if result.status_code == 200:
-		data = json.loads(result.content)
-		item_data = data.get('response', {}).get('content', {})
-
-		if len(result.content) < defaults.MAX_MEMCACHE_LENGTH:
-			memcache.set(item_url, item_data, defaults.CACHE_TIME)
-		return item_data
-
-	return None
 
 def read_container(container_id, retries=3):
 	container_base_url = configuration.read('CONTAINER_API_BASE_URL')
@@ -57,7 +27,7 @@ def read_container(container_id, retries=3):
 			live_stories = data.get('collection', {}).get('live', [])
 			live_story_ids = [item['id'] for item in live_stories]
 			
-			return [read_capi_item(item_id) for item_id in live_story_ids]
+			return [capi.read_item(item_id) for item_id in live_story_ids]
 
 		return []
 

--- a/email_definitions/uk.py
+++ b/email_definitions/uk.py
@@ -22,7 +22,7 @@ class DailyEmail(handlers.EmailTemplate):
 		'leaderboard_v2': 'Bottom'
 	}
 
-	cache_bust=False
+	cache_bust=True
 
 	base_data_sources = immutable.make_dict({
 		'business': ds.BusinessDataSource(client),

--- a/email_definitions/uk.py
+++ b/email_definitions/uk.py
@@ -22,7 +22,7 @@ class DailyEmail(handlers.EmailTemplate):
 		'leaderboard_v2': 'Bottom'
 	}
 
-	cache_bust=True
+	cache_bust=False
 
 	base_data_sources = immutable.make_dict({
 		'business': ds.BusinessDataSource(client),


### PR DESCRIPTION
This simplified version of the CAPI item reader was being used inside the container API client but I've broken it out to simplify maintainence and also to avoid bloating the container functionality.