### PR TITLE
Tags: detect presence of a tag

### DIFF
--- a/data_source.py
+++ b/data_source.py
@@ -128,7 +128,7 @@ class ItemPlusBlogDataSource(DataSource):
 class MostSharedCountInterpolator(object):
     def interpolate(self, shared_count_list, content_list ):
         for( url, shared_count ) in shared_count_list:
-            if not url in [content_item for content_item in content_list
+            if not url in [content_item['webUrl'] for content_item in content_list
              if 'webUrl' in content_item and url in content_item['webUrl']]:
                 continue
             [content_item for content_item in content_list

--- a/tags.py
+++ b/tags.py
@@ -1,0 +1,6 @@
+
+def has_tag(tag_id, content_item):
+	if not 'tags' in content_item:
+		return false
+
+	return tag_id in [tag['id'] for tag in content_item['tags']]

--- a/test_runner.py
+++ b/test_runner.py
@@ -4,7 +4,6 @@ import sys
 import os
 import unittest
 
-
 USAGE = """%prog SDK_PATH
 Run unit tests for App Engine apps.
 
@@ -17,7 +16,7 @@ def main(sdk_path, test_path):
     import dev_appserver
     dev_appserver.fix_sys_path()
     suite = unittest.loader.TestLoader().discover(test_path)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    return unittest.TextTestRunner(verbosity=2).run(suite)
 
 
 if __name__ == '__main__':
@@ -29,4 +28,10 @@ if __name__ == '__main__':
         sys.exit(1)
     TEST_PATH = "tests"
     SDK_PATH = args[0]
-    main(SDK_PATH, TEST_PATH)
+    result = main(SDK_PATH, TEST_PATH)
+    if result.wasSuccessful():
+        sys.exit(0)
+
+    print 'Tests failed'
+
+    sys.exit(1)

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -68,6 +68,10 @@ class TestDataSources(unittest.TestCase):
     def check_data_source_url(self, data_source, expected_path, **expected_args):
         expected_args['api-key'] = API_KEY
         expected_args['format'] = 'json'
+        expected_args['show-elements'] = 'image'
+
+        if not 'show-tags' in expected_args:
+          expected_args['show-tags'] = 'tone,type,keyword'
 
         if not expected_args.has_key('tag'):
             expected_args['tag'] = '-news/series/picture-desk-live'
@@ -424,15 +428,6 @@ class TestDataSources(unittest.TestCase):
         assert result['id'] == 'section id'
         assert result['sectionName'] == 'Politics'
         assert result['sectionId'] == 'politics'
-
-
-
-
-
-    def test_multi_content_data_source_should_barf_if_content_ids_is_left_unset(self):
-        data_source = MultiContentDataSource('cheese_client', 'cheese_name')
-        with self.assertRaises(DataSourceException):
-            data_source.fetch_data()
 
     def test_multi_content_data_source_should_return_data_in_correct_format(self):
         client = ContentIdRememberingStubClient()

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,19 @@
+import unittest
+
+import tags
+
+class TestTags(unittest.TestCase):
+
+    def test_should_detect_whether_a_tag_present(self):
+    	stub_content_item = {
+    		'tags': [
+	    		{
+	    			'id': 'world/syria'
+	    		}
+    		]
+    	}
+
+    	self.assertTrue(tags.has_tag('world/syria', stub_content_item))
+
+    def test_should_detect_whether_a_tag_is_absent(self):
+    	pass

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -2,18 +2,18 @@ import unittest
 
 import tags
 
+stub_content_item = {
+	'tags': [
+		{
+			'id': 'world/syria'
+		}
+	]
+}
+
 class TestTags(unittest.TestCase):
 
     def test_should_detect_whether_a_tag_present(self):
-    	stub_content_item = {
-    		'tags': [
-	    		{
-	    			'id': 'world/syria'
-	    		}
-    		]
-    	}
-
     	self.assertTrue(tags.has_tag('world/syria', stub_content_item))
 
     def test_should_detect_whether_a_tag_is_absent(self):
-    	pass
+    	self.assertFalse(tags.has_tag('world/iraq', stub_content_item))


### PR DESCRIPTION
As part of the rework of the Australian Politics newsletter we want to be able to say whether a piece of content has the Australia Politics tag or not.

I also discovered that the test runner was broken for CI in that it wasn't returning an error status and therefore we had been breaking a number of the tests without realising it. This should be fixed now, along with the tests that had been broken for a while.