### PR TITLE
Categories fixes

### DIFF
--- a/email_definitions/uk.py
+++ b/email_definitions/uk.py
@@ -71,7 +71,7 @@ class DailyEmail(handlers.EmailTemplate):
 		'v2015': base_priorities,
 		'nhs': base_priorities.cons(('nhs_special', 2)),
 		'categories': immutable.make_list(
-			('breaking', 1),
+			('breaking', 5),
 			('canonical', 6),
 			('special', 1),
 			).concat(base_priorities.without(('top_stories', 6))),

--- a/template/uk/daily/categories.html
+++ b/template/uk/daily/categories.html
@@ -24,7 +24,7 @@
         standfirst=False,
         always_show=False) }}
 
-    {{ layout.story_trail(heading_text='Editor\'s picks',
+    {{ layout.story_trail(heading_text='Headlines',
         stories=canonical,
         heading_link='http://www.theguardian.com',
         heading_colour='#c22d05',


### PR DESCRIPTION
A couple of changes based on editorial requests:

> - Top stories query expanded to contain 5 stories 
> - 'Editors picks' subheader to be renamed to 'Headlines'