### PR TITLE
Australia: Daily email: front tag version

### DIFF
--- a/email_definitions/au.py
+++ b/email_definitions/au.py
@@ -28,7 +28,7 @@ discussion_client = DiscussionClient(mr.discussion_base_url)
 
 class DailyEmailAUS(handlers.EmailTemplate):
     recognized_versions = ['v1', 'v2', 'v3', 'v2015', 'v4']
-    cache_bust=True
+    cache_bust=False
 
     ad_tag = 'email-guardian-today-aus'
     ad_config = {

--- a/email_definitions/au.py
+++ b/email_definitions/au.py
@@ -27,7 +27,8 @@ ophan_client = OphanClient(mr.ophan_base_url, mr.ophan_key)
 discussion_client = DiscussionClient(mr.discussion_base_url)
 
 class DailyEmailAUS(handlers.EmailTemplate):
-    recognized_versions = ['v1', 'v2', 'v3', 'v2015']
+    recognized_versions = ['v1', 'v2', 'v3', 'v2015', 'v4']
+    cache_bust=True
 
     ad_tag = 'email-guardian-today-aus'
     ad_config = {
@@ -59,6 +60,11 @@ class DailyEmailAUS(handlers.EmailTemplate):
             eye_witness=ds.EyeWitnessDataSource(clientAUS),
             most_shared=dss.social.most_shared(clientAUS, ophan_client, 'au')),
         'v2015': base_data_sources,
+        'v4': base_data_sources.using(
+            breaking = container.for_front('au', 'breaking'),
+            canonical = container.for_front('au', 'canonical'),
+            special = container.for_front('au', 'special'),
+        ),
     }
 
     base_priorities = immutable.make_list(
@@ -78,13 +84,19 @@ class DailyEmailAUS(handlers.EmailTemplate):
         'v2': base_priorities.concat(immutable.make_list(('eye_witness', 1))),
         'v3': base_priorities.concat(immutable.make_list(('most_shared', 6))),
         'v2015': base_priorities,
+        'v4': immutable.make_list(
+            ('breaking', 5),
+            ('canonical', 6),
+            ('special', 1),
+            ).concat(base_priorities.without(('top_stories', 6))),
         })
 
     template_names = immutable.make_dict({
         'v1': 'au/daily/v1',
         'v2': 'au/daily/v2',
         'v3': 'au/daily/v3',
-        'v2015': 'au/daily/v2015'
+        'v2015': 'au/daily/v2015',
+        'v4': 'au/daily/v4',
     })
 
 class Politics(handlers.EmailTemplate):

--- a/template/au/daily/v4.html
+++ b/template/au/daily/v4.html
@@ -1,0 +1,113 @@
+{# Daily (Guardian Today) email template #}
+
+{% extends 'base_email.html' %}
+{% import 'macro/layout.html' as layout %}
+
+
+{% set title = 'the guardian today - Australia edition' %}
+{% set title_link = 'http://www.theguardian.com/au' %}
+{% set title_colour = '#333333' %}
+{% set logo_background = '#004179' %}
+{% set facebook_page = 'theguardianaustralia' %}
+{% set twitter_account = 'GuardianAus' %}
+{% set footer_colour = 'light' %}
+
+{% block title %}Guardian Today - Australia edition{% endblock %}
+
+{% block content %}
+
+    {{ layout.story_trail(heading_text='Top stories',
+        stories=breaking,
+        heading_link='http://www.theguardian.com/au',
+        heading_colour='#c22d05',
+        top_thumb=True,
+        standfirst=False,
+        always_show=False) }}
+
+    {{ layout.story_trail(heading_text='Headlines',
+        stories=canonical,
+        heading_link='http://www.theguardian.com/au',
+        heading_colour='#c22d05',
+        top_thumb=True,
+        standfirst=False) }}
+
+    {{ layout.story_trail(heading_text='Special report',
+        stories=special,
+        heading_link='http://www.theguardian.com/au',
+        heading_colour='#c22d05',
+        top_thumb=True,
+        standfirst=False,
+        always_show=False) }}
+
+    {{ layout.advert(ads.leaderboard_v1) }}
+
+    {{ layout.story_trail(
+    heading_text='Sport',
+    stories=aus_sport,
+    heading_link='http://www.theguardian.com/au/sport',
+    heading_colour='#20a111',
+    standfirst=False) }}
+
+    {{ layout.story_trail(
+    heading_text='Culture',
+    stories=culture,
+    heading_link='http://www.theguardian.com/au/culture',
+    heading_colour='#d1008b',
+    standfirst=False) }}
+
+    {{ layout.advert(ads.leaderboard_v2) }}
+
+    {{ layout.story_trail(
+    heading_text='Comment is free',
+    stories=comment,
+    heading_link='http://www.theguardian.com/au/commentisfree',
+    heading_colour='#0061a6',
+    standfirst=False) }}
+
+    {{ layout.story_trail(
+    heading_text='Life and style',
+    stories=lifeandstyle,
+    heading_link='http://www.theguardian.com/lifeandstyle',
+    heading_colour='#ea721e',
+    standfirst=False) }}
+
+    {{ layout.story_trail(
+    heading_text='Technology',
+    stories=technology,
+    heading_link='http://www.theguardian.com/technology',
+    heading_colour='#d61d00',
+    standfirst=False) }}
+
+    {{ layout.story_trail(
+    heading_text='Science',
+    stories=science,
+    heading_link='http://www.theguardian.com/science',
+    heading_colour='#d61d00',
+    standfirst=False) }}
+
+    {{ layout.story_trail(
+    heading_text='Environment',
+    stories=environment,
+    heading_link='http://www.theguardian.com/environment',
+    heading_colour='#7bbb00',
+    standfirst=False) }}
+
+    {{ layout.story_trail(
+    heading_text='Video',
+    stories=video,
+    heading_link='http://www.theguardian.com/australia-news+content/video?view=beta',
+    heading_colour='#0061A6',
+    standfirst=False) }}
+
+    {{ layout.story_trail(heading_text='Most viewed in last 24 hours',
+    stories=most_viewed,
+    heading_link='http://www.theguardian.com/mostviewed',
+    heading_colour='#2470a6',
+    top_thumb=True,
+    standfirst=False) }}
+
+{% endblock content %}
+
+{% set sections = (('Sport', 'http://www.theguardian.com/au/sport'),
+('Culture', 'http://www.theguardian.com/au/culture'),
+('Comment is free', 'http://www.theguardian.com/au/commentisfree')) %}

--- a/template/index.html
+++ b/template/index.html
@@ -53,7 +53,7 @@
                 <tr>
                     <td style="padding: 10px 20px 20px 20px;">
                     Daily Email - Australia edition
-                        <a class="story-title" href="/daily-email-aus/v1" >v1</a> | <a class="story-title" href="/daily-email-aus/v2" >v2 - with Eyewitness</a> | <a class="story-title" href="/daily-email-aus/v3" >v3 - with MostShared</a> | <a class="story-title" href="/daily-email-aus/v2015" >v2015</a> | <a class="story-title" href="/headline/au">headline</a>
+                        <a class="story-title" href="/daily-email-aus/v1" >v1</a> | <a class="story-title" href="/daily-email-aus/v2" >v2 - with Eyewitness</a> | <a class="story-title" href="/daily-email-aus/v3" >v3 - with MostShared</a> | <a class="story-title" href="/daily-email-aus/v2015" >v2015</a> | <a class="story-title" href="/daily-email-aus/v4" >v4</a> | <a class="story-title" href="/headline/au">headline</a>
                     </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
This introduces a version of the Australian email that matches that of the UK categories email.

![au-daily-categories](https://cloud.githubusercontent.com/assets/7312/16485650/038be0ca-3eb8-11e6-8cd7-ba1878d117a7.png)
