### PR TITLE
remove how to draw from bookmarks v2

### DIFF
--- a/template/culture/bookmarks/v2.html
+++ b/template/culture/bookmarks/v2.html
@@ -55,13 +55,6 @@
         heading_colour='#d1008b',
         top_thumb=True) }}
 
-{{ layout.trail_image(
-    image=how_to_draw,
-    heading_text='How to draw',
-    heading_link='http://www.theguardian.com/childrens-books-site/series/how-to-draw',
-    heading_colour='#d1008b') }}
-
 {% endblock content %}
 
 {% block footer %}{% endblock footer %}
-


### PR DESCRIPTION
requested as 'how to draw' is no longer maintained

there are other references to 'how to draw' which are still in place, these can be removed if needed