### PR TITLE
Remove calls to decommisioned ad server

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -110,11 +110,6 @@ class EmailTemplate(webapp2.RequestHandler):
 
             ads = {}
 
-            if hasattr(self, 'ad_tag') and self.ad_tag:
-                ad_fetcher = AdFetcher(self.ad_tag)
-                for name, type in self.ad_config.iteritems():
-                    ads[name] = ad_fetcher.fetch_type(type)
-
             page = template.render(ads=ads, date=date, data=self.additional_template_data(), title_overrides=title_overrides, **trail_blocks)
 
             if self.minify:


### PR DESCRIPTION
`oas.theguardian.com` went away and broke a number of mails. This PR disables the calls to it whilst we investigate whether it was still required