### PR TITLE
Make the template (just zip file currently) work for video atoms.

### DIFF
--- a/data_source.py
+++ b/data_source.py
@@ -21,6 +21,7 @@ class DataSource(object):
         self.page_size = 10
         self.content_type = None
         self.show_elements = None
+        self.show_atoms = None
         self.from_date = None
         self.show_most_viewed = False
         self.short_url = None
@@ -73,7 +74,7 @@ class DataSource(object):
 
         criteria['user-tier']='internal'
 
-        for attr in ['production_office', 'section', 'show_elements']:
+        for attr in ['production_office', 'section', 'show_elements', 'show_atoms']:
             attr_value = getattr(self,attr)
             if attr_value:
                 criteria[attr] = attr_value

--- a/data_sources/technology.py
+++ b/data_sources/technology.py
@@ -31,4 +31,5 @@ class TechnologyVideoDataSource(SearchDataSource):
         self.content_type = 'video'
         self.tags = ['technology/technology']
         self.show_elements = 'video'
+        self.show_atoms='media'
 

--- a/handlers.py
+++ b/handlers.py
@@ -36,6 +36,7 @@ jinja_environment.filters.update({
         'get_keyword': template_filters.get_keyword,
         'image_of_width': template_filters.image_of_width,
         'asset_url': template_filters.asset_url,
+        'get_video_assets': template_filters.get_video_assets
     })
 
 jinja_environment.cache=None

--- a/template/macro/layout.html
+++ b/template/macro/layout.html
@@ -48,24 +48,14 @@
 
 {% macro video(video, bg_colour='#424242', heading_text, heading_link, heading_colour='#424242', heading_text_colour='#ffffff', caption_colour='#ffffff') -%}
 {% set video = video[0] %}
-{% set picture = [video.elements[0].assets[0]] %}
-{% set stillImageUrl = picture.file %}
 
-{% for media_asset in video.elements[0].assets if '480' == media_asset.typeData.width or '460' == media_asset.typeData.width %}
-    {% if picture.append(media_asset) %}{% endif %}
-{% endfor %}
 
-{% if picture[1] %}
-    {% set picture = picture[1] %}
-    {% set stillImageUrl = picture.typeData.stillImageUrl %}
-{% else %}
-    {% set picture = picture[0] %}
-{% endif %}
+{% set pictureAsset = video | get_video_assets  %}
 
 <tr><td>
     <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="{{ bg_colour }}">
         <tr><td>{{ heading(heading_text=heading_text, link=heading_link, bg_colour=heading_colour, colour=heading_text_colour) }}</td></tr>
-        <tr><td align="left"><a href="{{ video.webUrl }}" border="0"><img src="{{ picture.file }}" width="100%" alt="{{ picture.typeData.altText }}" border="0" /></a></td></tr>
+        <tr><td align="left"><a href="{{ video.webUrl }}" border="0"><img src="{{ pictureAsset.file }}" width="100%" alt="{{ pictureAsset.altText }}" border="0" /></a></td></tr>
         <tr>
             <td style="padding: 10px 20px 20px 20px;">
                 <table width="100%" cellpadding="0" cellspacing="0" border="0">

--- a/util.py
+++ b/util.py
@@ -1,0 +1,9 @@
+
+def safeget(dct, page_type, *keys):
+    for key in keys:
+        try:
+            dct = dct[key]
+        except KeyError:
+            logging.error("Could not extract poster image and alt text for  " + page_type + + dict)
+            return None
+    return dct

--- a/util.py
+++ b/util.py
@@ -3,7 +3,7 @@ def safeget(dct, page_type, *keys):
     for key in keys:
         try:
             dct = dct[key]
-        except KeyError:
+        except (KeyError, UndefinedError) as e:
             logging.error("Could not extract poster image and alt text for  " + page_type + + dict)
             return None
     return dct


### PR DESCRIPTION
This change fixes the email renderer for video atoms. Currently they are broken due to not having an elements block. 

I've moved some of the logic that was previously in the template out into a template filter which hopefully makes it a bit more readable.