### PR TITLE
Garnett email renderer updates

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -129,5 +129,8 @@ class EmailTemplate(webapp2.RequestHandler):
 
 class Index(webapp2.RequestHandler):
     def get(self):
-        template = jinja_environment.get_template('index.html')
+        show_all = self.request.GET.get('showAll')
+        template_name = 'index.jan2018.html' if show_all else 'index.html'
+
+        template = jinja_environment.get_template(template_name)
         self.response.out.write(template.render())

--- a/handlers.py
+++ b/handlers.py
@@ -88,20 +88,16 @@ class EmailTemplate(webapp2.RequestHandler):
                 retrieved_data_map[key] = title
 
         return retrieved_data_map
-    
-    def show_header_and_footer(self):
-        show_them = self.request.GET.get('showHeaderAndFooter')
-        if show_them is None:
-            return True
-        else:
-            return not show_them == 'false'
 
     def get(self, version_id):
         self.check_version_id(version_id)
 
-        show_header_and_footer=self.show_header_and_footer()
-        cache_key = "{}-{}-showHeaderAndFooter={}".format(version_id, str(self.__class__), show_header_and_footer)
+        display = self.request.GET.get('display') or 'all'
+        cache_key = "{}-{}-{}".format(version_id, str(self.__class__), display)
         page = self.cache.get(cache_key)
+
+        show_header_and_footer = not display == 'content'
+        show_footer_links = not display == 'logo-footer'
 
         if self.cache_bust or not page:
             logging.debug('Cache miss with key: %s' % cache_key)
@@ -124,6 +120,7 @@ class EmailTemplate(webapp2.RequestHandler):
                 data=self.additional_template_data(),
                 title_overrides=title_overrides,
                 show_header_and_footer=show_header_and_footer,
+                show_footer_links=show_footer_links,
                 **trail_blocks
             )
 

--- a/handlers.py
+++ b/handlers.py
@@ -92,12 +92,8 @@ class EmailTemplate(webapp2.RequestHandler):
     def get(self, version_id):
         self.check_version_id(version_id)
 
-        display = self.request.GET.get('display') or 'all'
-        cache_key = "{}-{}-{}".format(version_id, str(self.__class__), display)
+        cache_key = "{}-{}".format(version_id, str(self.__class__))
         page = self.cache.get(cache_key)
-
-        show_header_and_footer = not display == 'content'
-        show_footer_links = not display == 'logo-footer'
 
         if self.cache_bust or not page:
             logging.debug('Cache miss with key: %s' % cache_key)
@@ -119,8 +115,6 @@ class EmailTemplate(webapp2.RequestHandler):
                 date=date,
                 data=self.additional_template_data(),
                 title_overrides=title_overrides,
-                show_header_and_footer=show_header_and_footer,
-                show_footer_links=show_footer_links,
                 **trail_blocks
             )
 

--- a/template/base_email.html
+++ b/template/base_email.html
@@ -59,7 +59,7 @@
                         <tr align="left"><td style="font-family: Arial, sans-serif; font-size: 12px; color: #666666; padding-top: 3px;">{{ date }}</td></tr>
                       </table>
                     </td>
-                    <td align="center" bgcolor="{{ logo_background }}" style="font-weight: bold; font-family: Georgia, serif; color: #ffffff;" width="92px"><img src="https://image.mail.theguardian.com/lib/fe961570706d047f7d/m/2/g_logo_email2.png" alt="The Guardian logo" width="92px" height="64px"></td>
+                    <td align="center" bgcolor="{{ logo_background }}" style="font-weight: bold; font-family: Georgia, serif; color: #ffffff;" width="92px"><img src="https://uploads.guim.co.uk/2018/01/15/email_headers-36.png" alt="The Guardian logo" width="92px" height="64px"></td>
                   </tr>
                 </table>
                 <!-- /header -->
@@ -78,7 +78,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" border="0">
                         <tr>
                           <td align="left" width="50%">
-                              <a href="{% if footer_link %}{{ footer_link }}{% else %}{{ title_link }}{% endif %}"><img src="{{ URL_ROOT }}/static/img/logo-footer-{{ footer_colour }}.png" width="131" height="24" alt="The Guardian" border="0" /></a>
+                              <a href="{% if footer_link %}{{ footer_link }}{% else %}{{ title_link }}{% endif %}"><img src="https://uploads.guim.co.uk/2018/01/15/email_headers-37.png" width="136" height="44" alt="The Guardian" border="0" /></a>
                           </td>
                         </tr>
                       </table>

--- a/template/base_email.html
+++ b/template/base_email.html
@@ -77,13 +77,14 @@
                 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="{% if footer_colour == 'dark' %}#333333{% else %}#e8e5e2{% endif %}">
                   <!-- logo-social -->
                   <tr>
-                    <td style="padding: 20px 15px 0 15px;">
+                    <td style="padding: 20px 15px;">
                       <table width="100%" cellpadding="0" cellspacing="0" border="0">
                         <tr>
                           <td align="left" width="50%">
                               <a href="{% if footer_link %}{{ footer_link }}{% else %}{{ title_link }}{% endif %}"><img src="{{ URL_ROOT }}/static/img/logo-footer-{{ footer_colour }}.png" width="131" height="24" alt="The Guardian" border="0" /></a>
                           </td>
 
+                          {% if show_footer_links %}
                           <td width="50%" align="right">
                             <table cellpadding="0" cellspacing="0" border="0">
                               {% block social %}
@@ -98,13 +99,16 @@
                               {% endblock social %}
                             </table>
                           </td>
+                          {% endif %}
                         </tr>
                       </table>
                     </td>
                   </tr>
+                  <tr></tr>
                   <!-- /logo-social -->
 
                   <!-- sections -->
+                  {% if show_footer_links %}
                   {% block sections %}
                   <tr>
                     <td style="padding: 20px 15px 20px 15px;">
@@ -122,9 +126,11 @@
                     </td>
                   </tr>
                   {% endblock sections %}
+                  {% endif %}
                   <!-- /sections -->
                 </table>
 
+                {% if show_footer_links %}
                 {% block footer_link %}
                 <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="{% if footer_colour == 'dark' %}#444444{% else %}#ededed{% endif %}" style="border-bottom: 1px solid #bebebe;">
                   <tr><td align="left" style="padding: 20px 15px 20px 15px;">
@@ -132,6 +138,7 @@
                   </td></tr>
                 </table>
                 {% endblock footer_link %}
+                {% endif %}
 
                 <!-- /footer -->
             </td></tr>

--- a/template/base_email.html
+++ b/template/base_email.html
@@ -48,7 +48,6 @@
       <tr>
         <td align="center">
           <table class="content-holder" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#faf9f8" style="min-width: 320px; max-width: 600px; display: block;">
-            {% if show_header_and_footer %}
             {% block header %}
             <tr><td>
                 <!-- header -->
@@ -66,11 +65,9 @@
                 <!-- /header -->
             </td></tr>
             {% endblock %}
-            {% endif %}
 
             {% block content %}{% endblock %}
 
-            {% if show_header_and_footer %}
             {% block footer %}
             <tr><td>
                 <!-- footer -->
@@ -83,23 +80,6 @@
                           <td align="left" width="50%">
                               <a href="{% if footer_link %}{{ footer_link }}{% else %}{{ title_link }}{% endif %}"><img src="{{ URL_ROOT }}/static/img/logo-footer-{{ footer_colour }}.png" width="131" height="24" alt="The Guardian" border="0" /></a>
                           </td>
-
-                          {% if show_footer_links %}
-                          <td width="50%" align="right">
-                            <table cellpadding="0" cellspacing="0" border="0">
-                              {% block social %}
-                              <tr>
-                                {% if twitter_account %}
-                                <td align="left" width="50"><a href="https://www.twitter.com/{{ twitter_account }}"><img src="{{ URL_ROOT }}/static/img/twitter-{{ footer_colour }}.png" border="0" width="25" height="25" style="float: left;" /></a></td>
-                                {% endif %}
-                                {% if facebook_page %}
-                                <td align="left" width="25"><a href="https://www.facebook.com/{{ facebook_page }}"><img src="{{ URL_ROOT }}/static/img/fb-{{ footer_colour }}.png" border="0" width="25" height="25" style="float: left;" /></a></td>
-                                {% endif %}
-                              </tr>
-                              {% endblock social %}
-                            </table>
-                          </td>
-                          {% endif %}
                         </tr>
                       </table>
                     </td>
@@ -107,43 +87,11 @@
                   <tr></tr>
                   <!-- /logo-social -->
 
-                  <!-- sections -->
-                  {% if show_footer_links %}
-                  {% block sections %}
-                  <tr>
-                    <td style="padding: 20px 15px 20px 15px;">
-                      {% if sections %}
-                      <table cellpadding="0" cellspacing="0" border="0">
-                        <tr>
-                          {% for section in sections %}
-                          <td>
-                            <a style="font: 12px Helvetica, Arial, sans-serif; color: {% if footer_colour == 'dark' %}#ffffff{% else %}#005689{% endif %}; text-decoration: none; padding: 0 5px{% if loop.first %} 0 0{% endif %};{% if not loop.last %} border-right: 1px solid {% if footer_colour == 'dark' %}#bebebe{% else %}#999999{% endif %};{% endif %}; white-space: nowrap;" href="{{ section[1] }}">{{ section[0] }}</a>
-                          </td>
-                          {% endfor %}
-                        </tr>
-                      </table>
-                      {% endif %}
-                    </td>
-                  </tr>
-                  {% endblock sections %}
-                  {% endif %}
-                  <!-- /sections -->
                 </table>
-
-                {% if show_footer_links %}
-                {% block footer_link %}
-                <table width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="{% if footer_colour == 'dark' %}#444444{% else %}#ededed{% endif %}" style="border-bottom: 1px solid #bebebe;">
-                  <tr><td align="left" style="padding: 20px 15px 20px 15px;">
-                      <a href="https://profile.theguardian.com/email-prefs" style="font: 13px Helvetica, Arial, sans-serif; color: {% if footer_colour == 'dark' %}#ffffff{% else %}#005689{% endif %}; text-decoration: none;"><img src="{{ URL_ROOT }}/static/img/email-{{ footer_colour }}.png" border="0" style="vertical-align: -4px; margin-right: 5px;" width="25" height="18" alt="" /> Get more Guardian emails</a>
-                  </td></tr>
-                </table>
-                {% endblock footer_link %}
-                {% endif %}
 
                 <!-- /footer -->
             </td></tr>
             {% endblock %}
-            {% endif %}
           </table>
         </td>
       </tr>

--- a/template/base_email.html
+++ b/template/base_email.html
@@ -1,5 +1,5 @@
 {% if not footer_colour %}
-{% set footer_colour = 'dark' %}
+{% set footer_colour = 'light' %}
 {% endif %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
           "http://www.w3.org/TR/html4/loose.dtd">

--- a/template/index.html
+++ b/template/index.html
@@ -4,8 +4,7 @@
 
 {% set title = 'Email renderer' %}
 {% set title_link = '/' %}
-{% set title_colour = '#333' %}
-{% set logo_background  = '#333' %}
+{% set footer_colour = 'light' %}
 
 {% block content %}
 <style>

--- a/template/index.html
+++ b/template/index.html
@@ -20,151 +20,69 @@
     <table width="600px" cellpadding="0" cellspacing="0" border="0">
         <tr><td style="padding: 10px 20px 20px 20px; border-top: 1px solid #dedede; color: #999;">
             <table width="100%" cellpadding="0" cellspacing="0" border="0">
-                <tbody><tr>
+                <tbody>
+                    <tr>
+                        This tool should not be used for new emails.
+                        Please contact the <a href="mailto:digitalcms.dev@guardian.co.uk">Digital CMS Team</a>.
+                    </tr>
+                    <tr>
+                        <td style="padding: 10px 20px 20px 20px;">
+                            UK Daily Email
+                            <a class="story-title" href="/daily-email/categories" >Categories</a>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="padding: 10px 20px 20px 20px;">
+                            Best of US Opinion
+                            <a class="story-title" href="/us-opinion/v1" >v1</a>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="padding: 10px 20px 20px 20px;">
+                        Daily Email - Australia edition
+                            <a class="story-title" href="/daily-email-aus/v4" >v4</a>
+                        </td>
+                    </tr> 
+
+                    <tr>
+                        <td style="padding: 10px 20px 20px 20px;">
+                            Australian politics
+                            <a class="story-title" href="/australian-politics/v4" >v4</a>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="padding: 10px 20px 20px 20px;">
+                            <a class="story-title" href="/australian-cif/v1" >Australian CiF</a>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="padding: 10px 20px 20px 20px;">
+                            <a class="story-title" href="/australia-sport/v1" >Australian Sport</a>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="padding: 10px 20px 20px 20px;">
+                            Close up
+                            <a class="story-title" href="/close-up/v2" >v2</a> |
+                            <a class="story-title" href="/close-up/v3" >v3</a>
+                        </td>
+                    </tr>
+
+                <tr>
                     <td style="padding: 10px 20px 20px 20px;">
-                        UK Daily Email, <a class="story-title" href="/daily-email/v1" > v1</a> |
-                        <a class="story-title" href="/daily-email/v1-register" > v1-register</a> |
-                        <a class="story-title" href="/daily-email/v2015" > v2015</a> |
-                         <a class="story-title" href="/headline" >headline</a> |
-                        <a class="story-title" href="/daily-email/india" >India</a> |
-                        <a class="story-title" href="/daily-email/nhs" >NHS special</a> |
-                        <a class="story-title" href="/daily-email/categories" >Categories</a>
-                    </td>
-                </tr><tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        Daily Email - US edition: <a class="story-title" href="/daily-email-us/v1" >v1</a> |
-                        <a class="story-title" href="/daily-email-us/v3" >v3</a> |
-                        <a class="story-title" href="/daily-email-us/v6" >v6</a> |
-                        <a class="story-title" href="/daily-email-us/v7" >v7</a> |
-                        <a class="story-title" href="/daily-email-us/v2015" >v2015</a> |
-                        <a class="story-title" href="/daily-email-us/v2015_v2" >v2015_v2</a> |
-                        <a class="story-title" href="/daily-email-us/v2015_v3" >v2015_v3</a> |
-                        <a class="story-title" href="/daily-email-us/v2015_v4" >v2015_v4</a> |
-                        <a class="story-title" href="/daily-email-us/categories_us" >categories_us</a> |
-                        <a class="story-title" href="/headline/us">headline</a>
+                        Film today email
+                        <a class="story-title" href="/film-today/v2" >v2</a>
                     </td>
                 </tr>
 
                 <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        Best of US Opinion <a class="story-title" href="/us-opinion/v1" >v1</a> | <a class="story-title" href="/us-opinion/v2" >v2</a> | <a class="story-title" href="/us-opinion/v3" >v3</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                    Daily Email - Australia edition
-                        <a class="story-title" href="/daily-email-aus/v1" >v1</a> | <a class="story-title" href="/daily-email-aus/v2" >v2 - with Eyewitness</a> | <a class="story-title" href="/daily-email-aus/v3" >v3 - with MostShared</a> | <a class="story-title" href="/daily-email-aus/v2015" >v2015</a> | <a class="story-title" href="/daily-email-aus/v4" >v4</a> | <a class="story-title" href="/headline/au">headline</a>
-                    </td>
-                </tr>
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        Australian politics <a class="story-title" href="/australian-politics/v1" >v1</a>
-                        | <a class="story-title" href="/australian-politics/v2" >v2</a>
-                        | <a class="story-title" href="/australian-politics/v3" >v3</a>
-                        | <a class="story-title" href="/australian-politics/v4" >v4</a>
-                    </td>
-                </tr>
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/australian-cif/v1" >Australian CiF</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/australia-morning/v1" >Australian Morning Mail</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/australia-sport/v1" >Australian Sport</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        Long Reads: <a class="story-title" href="/longreads/v1" >v1</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/comment-is-free/v1" >Comment is free, v1</a> |
-                        <a class="story-title" href="/comment-is-free/v2" >v2</a> | <a class="story-title" href="/comment-is-free/v3">v3</a> | <a class="story-title" href="/headline/uk/opinion/v1">v1 headline</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/fashion-statement/v1" >Fashion statement, v1</a> | <a class="story-title" href="/fashion-statement/v2" >v2</a>
- | <a class="story-title" href="/fashion-statement/v3" >v3</a>
-                    </td>
-                </tr><tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/media-briefing/v1" >Media briefing</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        Bookmarks: <a class="story-title" href="/bookmarks/v1" >v1</a> | <a class="story-title" href="/bookmarks/v2" >v2</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/close-up/v1" >Close up, v1</a> |
-                        <a class="story-title" href="/close-up/v2" >v2</a> |
-                        <a class="story-title" href="/close-up/v3" >v3</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        Film today email <a class="story-title" href="/film-today/v1" >v1</a> | <a class="story-title" href="/film-today/v2" >v2</a> | <a class="story-title" href="/film-today/v3" >v3</a> | <a class="story-title" href="/film-today/v4" >v4</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        Film Today headlines <a href="/headline/film/v1" class="story-title">v1</a> | <a href="/headline/film" class="story-title">v2</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/sleeve-notes/v1" >Sleeve notes, v1</a> |
-                        <a class="story-title" href="/sleeve-notes/v2" >v2</a> |
-                        <a class="story-title" href="/sleeve-notes/v3" >v3</a>
-                    </td>
-                </tr>
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/the-flyer/v1" >The Flyer</a>
-                    </td>
-                </tr><tr>
                     <td style="padding: 10px 20px 20px 20px;">
                         <a class="story-title" href="/zip-file/v1" >Zip file</a>
-                    </td>
-                </tr>
-
-                <tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/most-commented/v1" >Most commented</a>
-                    </td>
-                </tr><tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/most-shared/v1" >Most shared (Global)</a> | <a class="story-title" href="/most-shared/uk/v1" >Most shared (UK)</a> | <a class="story-title" href="/most-shared/au/v1" >Most shared (AU)</a> | <a class="story-title" href="/most-shared/us/v1" >Most shared (US)</a>
-                    </td>
-                </tr><tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/most-viewed/v1" >Most viewed</a>
-                    </td>
-                </tr><tr>
-                    <td style="padding: 10px 20px 20px 20px;">
-                        <a class="story-title" href="/editors-picks/v1" >Editor's picks</a>
                     </td>
                 </tr>
 

--- a/template/index.jan2018.html
+++ b/template/index.jan2018.html
@@ -1,0 +1,176 @@
+{# Index template #}
+
+{% extends 'base_email.html' %}
+
+{% set title = 'Email renderer' %}
+{% set title_link = '/' %}
+{% set title_colour = '#333' %}
+{% set logo_background  = '#333' %}
+
+{% block content %}
+<style>
+  .story-title {
+    color: #005689;
+    font: 15px/19px Georgia, serif;
+    text-decoration: none;
+  }
+</style>
+
+<tr><td align="left">
+    <table width="600px" cellpadding="0" cellspacing="0" border="0">
+        <tr><td style="padding: 10px 20px 20px 20px; border-top: 1px solid #dedede; color: #999;">
+            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tbody><tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        UK Daily Email, <a class="story-title" href="/daily-email/v1" > v1</a> |
+                        <a class="story-title" href="/daily-email/v1-register" > v1-register</a> |
+                        <a class="story-title" href="/daily-email/v2015" > v2015</a> |
+                         <a class="story-title" href="/headline" >headline</a> |
+                        <a class="story-title" href="/daily-email/india" >India</a> |
+                        <a class="story-title" href="/daily-email/nhs" >NHS special</a> |
+                        <a class="story-title" href="/daily-email/categories" >Categories</a>
+                    </td>
+                </tr><tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        Daily Email - US edition: <a class="story-title" href="/daily-email-us/v1" >v1</a> |
+                        <a class="story-title" href="/daily-email-us/v3" >v3</a> |
+                        <a class="story-title" href="/daily-email-us/v6" >v6</a> |
+                        <a class="story-title" href="/daily-email-us/v7" >v7</a> |
+                        <a class="story-title" href="/daily-email-us/v2015" >v2015</a> |
+                        <a class="story-title" href="/daily-email-us/v2015_v2" >v2015_v2</a> |
+                        <a class="story-title" href="/daily-email-us/v2015_v3" >v2015_v3</a> |
+                        <a class="story-title" href="/daily-email-us/v2015_v4" >v2015_v4</a> |
+                        <a class="story-title" href="/daily-email-us/categories_us" >categories_us</a> |
+                        <a class="story-title" href="/headline/us">headline</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        Best of US Opinion <a class="story-title" href="/us-opinion/v1" >v1</a> | <a class="story-title" href="/us-opinion/v2" >v2</a> | <a class="story-title" href="/us-opinion/v3" >v3</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                    Daily Email - Australia edition
+                        <a class="story-title" href="/daily-email-aus/v1" >v1</a> | <a class="story-title" href="/daily-email-aus/v2" >v2 - with Eyewitness</a> | <a class="story-title" href="/daily-email-aus/v3" >v3 - with MostShared</a> | <a class="story-title" href="/daily-email-aus/v2015" >v2015</a> | <a class="story-title" href="/daily-email-aus/v4" >v4</a> | <a class="story-title" href="/headline/au">headline</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        Australian politics <a class="story-title" href="/australian-politics/v1" >v1</a>
+                        | <a class="story-title" href="/australian-politics/v2" >v2</a>
+                        | <a class="story-title" href="/australian-politics/v3" >v3</a>
+                        | <a class="story-title" href="/australian-politics/v4" >v4</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/australian-cif/v1" >Australian CiF</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/australia-morning/v1" >Australian Morning Mail</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/australia-sport/v1" >Australian Sport</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        Long Reads: <a class="story-title" href="/longreads/v1" >v1</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/comment-is-free/v1" >Comment is free, v1</a> |
+                        <a class="story-title" href="/comment-is-free/v2" >v2</a> | <a class="story-title" href="/comment-is-free/v3">v3</a> | <a class="story-title" href="/headline/uk/opinion/v1">v1 headline</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/fashion-statement/v1" >Fashion statement, v1</a> | <a class="story-title" href="/fashion-statement/v2" >v2</a>
+ | <a class="story-title" href="/fashion-statement/v3" >v3</a>
+                    </td>
+                </tr><tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/media-briefing/v1" >Media briefing</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        Bookmarks: <a class="story-title" href="/bookmarks/v1" >v1</a> | <a class="story-title" href="/bookmarks/v2" >v2</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/close-up/v1" >Close up, v1</a> |
+                        <a class="story-title" href="/close-up/v2" >v2</a> |
+                        <a class="story-title" href="/close-up/v3" >v3</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        Film today email <a class="story-title" href="/film-today/v1" >v1</a> | <a class="story-title" href="/film-today/v2" >v2</a> | <a class="story-title" href="/film-today/v3" >v3</a> | <a class="story-title" href="/film-today/v4" >v4</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        Film Today headlines <a href="/headline/film/v1" class="story-title">v1</a> | <a href="/headline/film" class="story-title">v2</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/sleeve-notes/v1" >Sleeve notes, v1</a> |
+                        <a class="story-title" href="/sleeve-notes/v2" >v2</a> |
+                        <a class="story-title" href="/sleeve-notes/v3" >v3</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/the-flyer/v1" >The Flyer</a>
+                    </td>
+                </tr><tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/zip-file/v1" >Zip file</a>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/most-commented/v1" >Most commented</a>
+                    </td>
+                </tr><tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/most-shared/v1" >Most shared (Global)</a> | <a class="story-title" href="/most-shared/uk/v1" >Most shared (UK)</a> | <a class="story-title" href="/most-shared/au/v1" >Most shared (AU)</a> | <a class="story-title" href="/most-shared/us/v1" >Most shared (US)</a>
+                    </td>
+                </tr><tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/most-viewed/v1" >Most viewed</a>
+                    </td>
+                </tr><tr>
+                    <td style="padding: 10px 20px 20px 20px;">
+                        <a class="story-title" href="/editors-picks/v1" >Editor's picks</a>
+                    </td>
+                </tr>
+
+            </tbody>
+            </table>
+        </td></tr>
+    </table>
+</td></tr>
+{% endblock content %}

--- a/tests/test_mail_renderer.py
+++ b/tests/test_mail_renderer.py
@@ -72,7 +72,6 @@ class TestRenderer(EmailTemplate):
 
 
 class TestMailRenderer(unittest.TestCase):
-    @unittest.skip("test runner needs updating for latest SDK")
     def test_should_use_data_sources_appropriate_to_version(self):
         renderer = TestRenderer()
         renderer.get('v2')
@@ -82,7 +81,6 @@ class TestMailRenderer(unittest.TestCase):
         for data_source in renderer.data_sources['v2'].values():
             self.assertTrue(data_source.data_fetched)
 
-    @unittest.skip("test runner needs updating for latest SDK")
     def test_should_use_template_appropriate_to_version(self):
         renderer = TestRenderer()
         renderer.get('v2')


### PR DESCRIPTION
The decision has been made to update the logos and remove the old social links at the bottom of the  mails. So that's what this PR does.

I've also reverted #54 (query param to disable header and footer) since it's no longer required. We also now have access to the spreadsheet showing what emails are still based on this renderer so I've updated the front page accordingly.

In case we've lost any links we actually need, the previous front page can be seen by sticking `?showAll=true` on the end.