### PR TITLE
Remove logo background customisation

### DIFF
--- a/template/au/comment-is-free/v1.html
+++ b/template/au/comment-is-free/v1.html
@@ -6,7 +6,6 @@
 {% set title = 'Comment is free Australia' %}
 {% set title_link = 'http://www.theguardian.com/au/commentisfree' %}
 {% set title_colour = '#005689' %}
-{% set logo_background  = '#ff5d00' %}
 {% set facebook_page = 'GuardianComment' %}
 {% set twitter_account = 'Cif_Australia' %}
 

--- a/template/au/daily/v1.html
+++ b/template/au/daily/v1.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today - Australia edition' %}
 {% set title_link = 'http://www.theguardian.com/au' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardianaustralia' %}
 {% set twitter_account = 'GuardianAus' %}
 {% set footer_colour = 'light' %}

--- a/template/au/daily/v2.html
+++ b/template/au/daily/v2.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today - Australia edition' %}
 {% set title_link = 'http://www.theguardian.com/au' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardianaustralia' %}
 {% set twitter_account = 'GuardianAus' %}
 {% set footer_colour = 'light' %}

--- a/template/au/daily/v2015.html
+++ b/template/au/daily/v2015.html
@@ -5,7 +5,6 @@
 {% set title = 'the guardian today - Australia edition' %}
 {% set title_link = 'http://www.theguardian.com/au' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardianaustralia' %}
 {% set twitter_account = 'GuardianAus' %}
 {% set footer_colour = 'light' %}

--- a/template/au/daily/v3.html
+++ b/template/au/daily/v3.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today - Australia edition' %}
 {% set title_link = 'http://www.theguardian.com/au' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardianaustralia' %}
 {% set twitter_account = 'GuardianAus' %}
 {% set footer_colour = 'light' %}

--- a/template/au/daily/v4.html
+++ b/template/au/daily/v4.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today - Australia edition' %}
 {% set title_link = 'http://www.theguardian.com/au' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardianaustralia' %}
 {% set twitter_account = 'GuardianAus' %}
 {% set footer_colour = 'light' %}

--- a/template/au/politics/v1.html
+++ b/template/au/politics/v1.html
@@ -6,7 +6,6 @@
 {% set title = 'Australian politics' %}
 {% set title_link = 'http://www.theguardian.com/world/australian-politics' %}
 {% set title_colour = '#c22d05' %}
-{% set logo_background  = '#961f02' %}
 {% set facebook_page = 'theguardianaustralia' %}
 {% set twitter_account = 'GuardianAus' %}
 {% set footer_link = 'http://www.theguardian.com/au' %}

--- a/template/au/politics/v2.html
+++ b/template/au/politics/v2.html
@@ -6,7 +6,6 @@
 {% set title = 'Australian politics' %}
 {% set title_link = 'http://www.theguardian.com/world/australian-politics' %}
 {% set title_colour = '#c22d05' %}
-{% set logo_background  = '#961f02' %}
 {% set facebook_page = 'theguardianaustralia' %}
 {% set twitter_account = 'GuardianAus' %}
 {% set footer_link = 'http://www.theguardian.com/au' %}

--- a/template/au/politics/v3.html
+++ b/template/au/politics/v3.html
@@ -6,7 +6,6 @@
 {% set title = 'Australian politics' %}
 {% set title_link = 'http://www.theguardian.com/world/australian-politics' %}
 {% set title_colour = '#c22d05' %}
-{% set logo_background  = '#961f02' %}
 {% set facebook_page = 'theguardianaustralia' %}
 {% set twitter_account = 'GuardianAus' %}
 {% set footer_link = 'http://www.theguardian.com/au' %}

--- a/template/au/sport/v1.html
+++ b/template/au/sport/v1.html
@@ -6,7 +6,6 @@
 {% set title = 'Guardian Australia Sport' %}
 {% set title_link = 'http://www.theguardian.com/au/sport' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardianaustralia' %}
 {% set twitter_account = 'GdnAusSport' %}
 

--- a/template/base_email.html
+++ b/template/base_email.html
@@ -59,7 +59,9 @@
                         <tr align="left"><td style="font-family: Arial, sans-serif; font-size: 12px; color: #666666; padding-top: 3px;">{{ date }}</td></tr>
                       </table>
                     </td>
-                    <td align="center" bgcolor="{{ logo_background }}" style="font-weight: bold; font-family: Georgia, serif; color: #ffffff;" width="92px"><img src="https://uploads.guim.co.uk/2018/01/15/email_headers-36.png" alt="The Guardian logo" width="92px" height="64px"></td>
+                    <td align="center" bgcolor="#121312" style="font-weight: bold; font-family: Georgia, serif; color: #ffffff;" width="92px">
+                      <img src="https://uploads.guim.co.uk/2018/01/15/email_headers-36.png" alt="The Guardian logo" width="92px" height="64px">
+                    </td>
                   </tr>
                 </table>
                 <!-- /header -->

--- a/template/comment-is-free/v1.html
+++ b/template/comment-is-free/v1.html
@@ -6,7 +6,6 @@
 {% set title = 'The best of Guardian opinion' %}
 {% set title_link = 'http://www.theguardian.com/uk/commentisfree' %}
 {% set title_colour = '#005689' %}
-{% set logo_background  = '#ff5d00' %}
 {% set facebook_page = 'GuardianComment' %}
 {% set twitter_account = 'commentisfree' %}
 

--- a/template/comment-is-free/v2.html
+++ b/template/comment-is-free/v2.html
@@ -6,7 +6,6 @@
 {% set title = 'The best of Guardian opinion' %}
 {% set title_link = 'http://www.theguardian.com/uk/commentisfree' %}
 {% set title_colour = '#005689' %}
-{% set logo_background  = '#ff5d00' %}
 {% set facebook_page = 'GuardianComment' %}
 {% set twitter_account = 'commentisfree' %}
 

--- a/template/comment-is-free/v3.html
+++ b/template/comment-is-free/v3.html
@@ -6,7 +6,6 @@
 {% set title = 'The best of Guardian opinion' %}
 {% set title_link = 'http://www.theguardian.com/uk/commentisfree' %}
 {% set title_colour = '#005689' %}
-{% set logo_background  = '#ff5d00' %}
 {% set facebook_page = 'GuardianComment' %}
 {% set twitter_account = 'commentisfree' %}
 

--- a/template/culture/bookmarks/v1.html
+++ b/template/culture/bookmarks/v1.html
@@ -6,7 +6,6 @@
 {% set title = 'Bookmarks' %}
 {% set title_link = 'http://www.theguardian.com/books' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page    = 'Guardian-Books' %}
 {% set twitter_account  = 'guardianbooks' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/culture/bookmarks/v2.html
+++ b/template/culture/bookmarks/v2.html
@@ -6,7 +6,6 @@
 {% set title = 'Bookmarks' %}
 {% set title_link = 'http://www.theguardian.com/books' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page    = 'Guardian-Books' %}
 {% set twitter_account  = 'guardianbooks' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/culture/close-up/v1.html
+++ b/template/culture/close-up/v1.html
@@ -6,7 +6,6 @@
 {% set title = 'Close up' %}
 {% set title_link = 'http://www.theguardian.com/film' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page    = 'guardianfilm' %}
 {% set twitter_account  = 'guardianfilm' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/culture/close-up/v2.html
+++ b/template/culture/close-up/v2.html
@@ -6,7 +6,6 @@
 {% set title = 'Close up' %}
 {% set title_link = 'http://www.theguardian.com/film' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page    = 'guardianfilm' %}
 {% set twitter_account  = 'guardianfilm' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/culture/close-up/v3.html
+++ b/template/culture/close-up/v3.html
@@ -6,7 +6,6 @@
 {% set title = 'Close up' %}
 {% set title_link = 'http://www.theguardian.com/film' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page    = 'guardianfilm' %}
 {% set twitter_account  = 'guardianfilm' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/culture/film-today/v1.html
+++ b/template/culture/film-today/v1.html
@@ -6,7 +6,6 @@
 {% set title = 'Film Today' %}
 {% set title_link = 'http://www.theguardian.com/film' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page = 'guardianfilm' %}
 {% set twitter_account = 'guardianfilm' %}
 

--- a/template/culture/film-today/v2.html
+++ b/template/culture/film-today/v2.html
@@ -6,7 +6,6 @@
 {% set title = 'Film Today' %}
 {% set title_link = 'http://www.theguardian.com/film' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page = 'guardianfilm' %}
 {% set twitter_account = 'guardianfilm' %}
 

--- a/template/culture/film-today/v3.html
+++ b/template/culture/film-today/v3.html
@@ -6,7 +6,6 @@
 {% set title = 'Film Today' %}
 {% set title_link = 'http://www.theguardian.com/film' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page = 'guardianfilm' %}
 {% set twitter_account = 'guardianfilm' %}
 

--- a/template/culture/film-today/v4.html
+++ b/template/culture/film-today/v4.html
@@ -6,7 +6,6 @@
 {% set title = 'Film Today' %}
 {% set title_link = 'http://www.theguardian.com/film' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page = 'guardianfilm' %}
 {% set twitter_account = 'guardianfilm' %}
 

--- a/template/culture/sleeve-notes/v1.html
+++ b/template/culture/sleeve-notes/v1.html
@@ -6,7 +6,6 @@
 {% set title = 'Sleeve notes' %}
 {% set title_link = 'http://www.theguardian.com/music' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page    = 'musicguardian' %}
 {% set twitter_account  = 'guardianmusic' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/culture/sleeve-notes/v2.html
+++ b/template/culture/sleeve-notes/v2.html
@@ -6,7 +6,6 @@
 {% set title = 'Sleeve notes' %}
 {% set title_link = 'http://www.theguardian.com/music' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page    = 'musicguardian' %}
 {% set twitter_account  = 'guardianmusic' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/culture/sleeve-notes/v3.html
+++ b/template/culture/sleeve-notes/v3.html
@@ -6,7 +6,6 @@
 {% set title = 'Sleeve notes' %}
 {% set title_link = 'http://www.theguardian.com/music' %}
 {% set title_colour = '#d1008b' %}
-{% set logo_background  = '#92005e' %}
 {% set facebook_page    = 'musicguardian' %}
 {% set twitter_account  = 'guardianmusic' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/fashion/fashion-statement/v1.html
+++ b/template/fashion/fashion-statement/v1.html
@@ -6,7 +6,6 @@
 {% set title = 'Fashion statement' %}
 {% set title_link = 'http://www.theguardian.com/fashion' %}
 {% set title_colour = '#ab1700' %}
-{% set logo_background  = '#ffc202' %}
 {% set facebook_page = 'GuardianFashion' %}
 {% set twitter_account = 'GuardianFashion' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/fashion/fashion-statement/v2.html
+++ b/template/fashion/fashion-statement/v2.html
@@ -6,7 +6,6 @@
 {% set title = 'Fashion statement' %}
 {% set title_link = 'http://www.theguardian.com/fashion' %}
 {% set title_colour = '#ab1700' %}
-{% set logo_background  = '#ffc202' %}
 {% set facebook_page = 'GuardianFashion' %}
 {% set twitter_account = 'GuardianFashion' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/fashion/fashion-statement/v3.html
+++ b/template/fashion/fashion-statement/v3.html
@@ -6,7 +6,6 @@
 {% set title = 'Fashion statement' %}
 {% set title_link = 'http://www.theguardian.com/fashion' %}
 {% set title_colour = '#ab1700' %}
-{% set logo_background  = '#ffc202' %}
 {% set facebook_page = 'GuardianFashion' %}
 {% set twitter_account = 'GuardianFashion' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/index.jan2018.html
+++ b/template/index.jan2018.html
@@ -5,7 +5,6 @@
 {% set title = 'Email renderer' %}
 {% set title_link = '/' %}
 {% set title_colour = '#333' %}
-{% set logo_background  = '#333' %}
 
 {% block content %}
 <style>

--- a/template/media/media-briefing.html
+++ b/template/media/media-briefing.html
@@ -6,7 +6,6 @@
 {% set title = 'Media briefing' %}
 {% set title_link = 'http://www.theguardian.com/media/series/media-briefing' %}
 {% set title_colour = '#c22d05' %}
-{% set logo_background  = '#961f02' %}
 {% set facebook_page = 'mediaguardian' %}
 {% set twitter_account = 'mediaguardian' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/technology/zip-file.html
+++ b/template/technology/zip-file.html
@@ -6,7 +6,6 @@
 {% set title = 'Zip File: Technology news from the Guardian' %}
 {% set title_link = 'http://www.theguardian.com/technology' %}
 {% set title_colour = '#c22d05' %}
-{% set logo_background  = '#961f02' %}
 {% set facebook_page = 'guardiantechnology' %}
 {% set twitter_account = 'guardiantech' %}
 {% set footer_link = 'http://www.theguardian.com' %}

--- a/template/travel/the-flyer.html
+++ b/template/travel/the-flyer.html
@@ -6,7 +6,6 @@
 {% set title = 'The Flyer: Your weekly round-up from Guardian Travel' %}
 {% set title_link = 'http://www.theguardian.com/travel' %}
 {% set title_colour = '#005689' %}
-{% set logo_background  = '#066ec9' %}
 {% set facebook_page = 'TravelGuardian' %}
 {% set twitter_account = 'GuardianTravel' %}
 

--- a/template/uk/daily/categories.html
+++ b/template/uk/daily/categories.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today' %}
 {% set title_link = 'http://www.theguardian.com' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardian' %}
 {% set twitter_account = 'guardian' %}
 {% set footer_colour = 'light' %}

--- a/template/uk/daily/india.html
+++ b/template/uk/daily/india.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today' %}
 {% set title_link = 'http://www.theguardian.com' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardian' %}
 {% set twitter_account = 'guardian' %}
 {% set footer_colour = 'light' %}

--- a/template/uk/daily/nhs.html
+++ b/template/uk/daily/nhs.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today' %}
 {% set title_link = 'http://www.theguardian.com' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardian' %}
 {% set twitter_account = 'guardian' %}
 {% set footer_colour = 'light' %}

--- a/template/uk/daily/v1-register.html
+++ b/template/uk/daily/v1-register.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today' %}
 {% set title_link = 'http://www.theguardian.com' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardian' %}
 {% set twitter_account = 'guardian' %}
 {% set footer_colour = 'light' %}

--- a/template/uk/daily/v1.html
+++ b/template/uk/daily/v1.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today' %}
 {% set title_link = 'http://www.theguardian.com' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardian' %}
 {% set twitter_account = 'guardian' %}
 {% set footer_colour = 'light' %}

--- a/template/uk/daily/v2015.html
+++ b/template/uk/daily/v2015.html
@@ -5,7 +5,6 @@
 {% set title = 'the guardian today' %}
 {% set title_link = 'http://www.theguardian.com' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'theguardian' %}
 {% set twitter_account = 'guardian' %}
 {% set footer_colour = 'light' %}

--- a/template/us/daily/categories_us.html
+++ b/template/us/daily/categories_us.html
@@ -5,7 +5,6 @@
 {% set title = 'the guardian today - US edition' %}
 {% set title_link = 'http://www.theguardian.com/us' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'GuardianUs' %}
 {% set twitter_account = 'GuardianUS' %}
 {% set footer_colour = 'light' %}

--- a/template/us/daily/v1.html
+++ b/template/us/daily/v1.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today - US edition' %}
 {% set title_link = 'http://www.theguardian.com/us' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'GuardianUs' %}
 {% set twitter_account = 'GuardianUS' %}
 {% set footer_colour = 'light' %}

--- a/template/us/daily/v2015.html
+++ b/template/us/daily/v2015.html
@@ -5,7 +5,6 @@
 {% set title = 'the guardian today - US edition' %}
 {% set title_link = 'http://www.theguardian.com/us' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'GuardianUs' %}
 {% set twitter_account = 'GuardianUS' %}
 {% set footer_colour = 'light' %}

--- a/template/us/daily/v2015_v2.html
+++ b/template/us/daily/v2015_v2.html
@@ -5,7 +5,6 @@
 {% set title = 'the guardian today - US edition' %}
 {% set title_link = 'http://www.theguardian.com/us' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'GuardianUs' %}
 {% set twitter_account = 'GuardianUS' %}
 {% set footer_colour = 'light' %}

--- a/template/us/daily/v2015_v3.html
+++ b/template/us/daily/v2015_v3.html
@@ -5,7 +5,6 @@
 {% set title = 'the guardian today - US edition' %}
 {% set title_link = 'http://www.theguardian.com/us' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'GuardianUs' %}
 {% set twitter_account = 'GuardianUS' %}
 {% set footer_colour = 'light' %}

--- a/template/us/daily/v2015_v4.html
+++ b/template/us/daily/v2015_v4.html
@@ -5,7 +5,6 @@
 {% set title = 'the guardian today - US edition' %}
 {% set title_link = 'http://www.theguardian.com/us' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'GuardianUs' %}
 {% set twitter_account = 'GuardianUS' %}
 {% set footer_colour = 'light' %}

--- a/template/us/daily/v3.html
+++ b/template/us/daily/v3.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today - US edition' %}
 {% set title_link = 'http://www.theguardian.com/us' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'GuardianUs' %}
 {% set twitter_account = 'GuardianUS' %}
 {% set footer_colour = 'light' %}

--- a/template/us/daily/v6.html
+++ b/template/us/daily/v6.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today - US edition' %}
 {% set title_link = 'http://www.theguardian.com/us' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'GuardianUs' %}
 {% set twitter_account = 'GuardianUS' %}
 {% set footer_colour = 'light' %}

--- a/template/us/daily/v7.html
+++ b/template/us/daily/v7.html
@@ -7,7 +7,6 @@
 {% set title = 'the guardian today - US edition' %}
 {% set title_link = 'http://www.theguardian.com/us' %}
 {% set title_colour = '#333333' %}
-{% set logo_background = '#004179' %}
 {% set facebook_page = 'GuardianUs' %}
 {% set twitter_account = 'GuardianUS' %}
 {% set footer_colour = 'light' %}

--- a/template/us/opinion/v1.html
+++ b/template/us/opinion/v1.html
@@ -6,7 +6,6 @@
 {% set title = 'Best of US Opinion' %}
 {% set title_link = 'http://www.theguardian.com/us/commentisfree' %}
 {% set title_colour = '#005689' %}
-{% set logo_background  = '#ff5d00' %}
 {% set facebook_page = 'GuardianComment' %}
 {% set twitter_account = 'CifAmerica' %}
 

--- a/template/us/opinion/v2.html
+++ b/template/us/opinion/v2.html
@@ -6,7 +6,6 @@
 {% set title = 'Best of US Opinion' %}
 {% set title_link = 'http://www.theguardian.com/us/commentisfree' %}
 {% set title_colour = '#005689' %}
-{% set logo_background  = '#ff5d00' %}
 {% set facebook_page = 'GuardianComment' %}
 {% set twitter_account = 'CifAmerica' %}
 

--- a/template/us/opinion/v3.html
+++ b/template/us/opinion/v3.html
@@ -6,7 +6,6 @@
 {% set title = 'Best of US Opinion' %}
 {% set title_link = 'http://www.theguardian.com/us/commentisfree' %}
 {% set title_colour = '#005689' %}
-{% set logo_background  = '#ff5d00' %}
 {% set facebook_page = 'GuardianComment' %}
 {% set twitter_account = 'CifAmerica' %}
 


### PR DESCRIPTION
There is only one logo. It is great. The dominance can no longer be challenged by upstart colours from a dead branding:

![australian_mobile](https://user-images.githubusercontent.com/395805/35039022-7e7d9434-fb74-11e7-8168-38250284e429.PNG)
