### PR TITLE
Update links on front page

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -28,13 +28,7 @@
                         <td style="padding: 10px 20px 20px 20px;">
                             UK Daily Email
                             <a class="story-title" href="/daily-email/categories" >Categories</a>
-                        </td>
-                    </tr>
-
-                    <tr>
-                        <td style="padding: 10px 20px 20px 20px;">
-                            Best of US Opinion
-                            <a class="story-title" href="/us-opinion/v1" >v1</a>
+                            <a class="story-title" href="/headline" >headline</a>
                         </td>
                     </tr>
 
@@ -61,6 +55,13 @@
                     <tr>
                         <td style="padding: 10px 20px 20px 20px;">
                             <a class="story-title" href="/australia-sport/v1" >Australian Sport</a>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="padding: 10px 20px 20px 20px;">
+                            Comment is free
+                            <a class="story-title" href="/headline/uk/opinion/v1">v1 headline</a>
                         </td>
                     </tr>
 

--- a/template/index.html
+++ b/template/index.html
@@ -27,7 +27,7 @@
                     <tr>
                         <td style="padding: 10px 20px 20px 20px;">
                             UK Daily Email
-                            <a class="story-title" href="/daily-email/categories" >Categories</a>
+                            <a class="story-title" href="/daily-email/categories" >Categories</a> |
                             <a class="story-title" href="/headline" >headline</a>
                         </td>
                     </tr>


### PR DESCRIPTION
Remove US opinion as they are now using the frontend email support. Put back two headline links that are still in use.

The rationale is that Celine is going on sabbatical soon and it's best for the page to reflect the reality of which bits are still in use to avoid confusing her cover.

You can still see all of the links with a query parameter: http://gu-email-renderer.appspot.com/?showAll=true.